### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix IDOR in match viewing and Markdown injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Insecure Direct Object Reference (IDOR) in `handle_view_match`.
 **Learning:** Checking object ownership is critical even when using hard-to-guess IDs (UUIDs). Defense in depth requires explicit authorization checks.
 **Prevention:** Always verify that the current user is authorized to access the requested resource (e.g., is a participant in the match) before returning sensitive data.
+
+## 2024-05-24 - Secure Match Viewing Implementation
+**Vulnerability:** IDOR in match profile viewing and Markdown formatting injection.
+**Learning:** Legacy Telegram Markdown requires manual escaping of user input. Match authorization checks were missing in callbacks.
+**Prevention:** Always verify relationship (e.g., match existence) before exposing profile details. Use `escapeMarkdown` utility for all user input in Markdown messages.

--- a/services/bot/src/handlers/matches.test.ts
+++ b/services/bot/src/handlers/matches.test.ts
@@ -137,6 +137,13 @@ describe('Matches List Handler', () => {
     it('should show user profile on view_match_user_', async () => {
       mockCtx.callbackQuery = { data: 'view_match_user_user2' } as any;
 
+      // Mock that they are matched
+      vi.mocked(matchService.getMatchList).mockReturnValue(
+        Effect.succeed(
+          createGetMatchListResponse([createMockMatch({ user1Id: '12345', user2Id: 'user2' })]),
+        ),
+      );
+
       const otherUser = createMockUser({
         id: 'user2',
         firstName: 'Jane',
@@ -159,8 +166,31 @@ describe('Matches List Handler', () => {
       );
     });
 
+    it('should deny access if users are not matched', async () => {
+      mockCtx.callbackQuery = { data: 'view_match_user_user2' } as any;
+
+      // Mock that they are NOT matched (empty list)
+      vi.mocked(matchService.getMatchList).mockReturnValue(
+        Effect.succeed(createGetMatchListResponse([])),
+      );
+
+      await matchesCallbacks(mockCtx as unknown as Context);
+
+      expect(mockCtx.editMessageText).toHaveBeenCalledWith(
+        expect.stringContaining('Access denied'),
+      );
+      expect(userService.getUser).not.toHaveBeenCalled();
+    });
+
     it("should show not found message if user doesn't exist", async () => {
       mockCtx.callbackQuery = { data: 'view_match_user_unknown' } as any;
+
+      // Mock that they are matched (so we pass the auth check)
+      vi.mocked(matchService.getMatchList).mockReturnValue(
+        Effect.succeed(
+          createGetMatchListResponse([createMockMatch({ user1Id: '12345', user2Id: 'unknown' })]),
+        ),
+      );
 
       vi.mocked(userService.getUser).mockReturnValue(Effect.succeed(createGetUserResponse(null)));
 
@@ -191,6 +221,13 @@ describe('Matches List Handler', () => {
 
     it('should handle errors gracefully when viewing user', async () => {
       mockCtx.callbackQuery = { data: 'view_match_user_user2' } as any;
+
+      // Mock that they are matched
+      vi.mocked(matchService.getMatchList).mockReturnValue(
+        Effect.succeed(
+          createGetMatchListResponse([createMockMatch({ user1Id: '12345', user2Id: 'user2' })]),
+        ),
+      );
 
       vi.mocked(userService.getUser).mockReturnValue(Effect.fail(new Error('Network error')));
 

--- a/services/bot/src/handlers/matches.ts
+++ b/services/bot/src/handlers/matches.ts
@@ -3,6 +3,7 @@ import type { Context } from 'grammy';
 import { InlineKeyboard } from 'grammy';
 
 import { captureEffectError } from '../lib/sentry.js';
+import { escapeMarkdown } from '../lib/security.js';
 import { matchService } from '../services/matchService.js';
 import { userService } from '../services/userService.js';
 import { mainMenuKeyboard } from '../ui/keyboards.js';
@@ -56,7 +57,7 @@ export const matchesCommand = (ctx: Context) =>
         const otherUser = userRes.user;
 
         if (otherUser) {
-          const name = otherUser.firstName || 'Unknown';
+          const name = escapeMarkdown(otherUser.firstName || 'Unknown');
           const age = otherUser.age || '?';
           const matchDate = match.matchedAt
             ? new Date(Number(match.matchedAt.seconds) * 1000).toLocaleDateString()
@@ -135,6 +136,23 @@ export const matchesCallbacks = (ctx: Context) =>
     if (data.startsWith('view_match_user_')) {
       const targetUserId = data.replace('view_match_user_', '');
 
+      // Authorization Check: Ensure the users are actually matched
+      const currentUserId = String(ctx.from.id);
+      const matchesRes = yield* _(matchService.getMatchList(currentUserId));
+      const matches = matchesRes.matches || [];
+      const isMatched = matches.some(
+        (m) => m.user1Id === targetUserId || m.user2Id === targetUserId,
+      );
+
+      if (!isMatched) {
+        yield* _(
+          Effect.tryPromise(() =>
+            ctx.editMessageText('Access denied: You are not matched with this user.'),
+          ),
+        );
+        return;
+      }
+
       const res = yield* _(userService.getUser(targetUserId));
       const user = res.user;
 
@@ -143,16 +161,19 @@ export const matchesCallbacks = (ctx: Context) =>
         return;
       }
 
-      const interests = user.interests?.join(', ') || 'None';
-      const location = user.location
-        ? `${user.location.city}, ${user.location.country}`
-        : 'Unknown';
+      const firstName = escapeMarkdown(user.firstName || 'Unknown');
+      const bio = escapeMarkdown(user.bio || 'No bio');
+      const interests = escapeMarkdown(user.interests?.join(', ') || 'None');
+      let location = 'Unknown';
+      if (user.location) {
+        location = escapeMarkdown(`${user.location.city}, ${user.location.country}`);
+      }
 
       const profileText = `
-👤 *${user.firstName}*, ${user.age || '?'}
-⚧ ${user.gender || 'Unknown'}
+👤 *${firstName}*, ${user.age || '?'}
+⚧ ${escapeMarkdown(user.gender || 'Unknown')}
 
-📝 ${user.bio || 'No bio'}
+📝 ${bio}
 
 🌟 Interests: ${interests}
 

--- a/services/bot/src/lib/security.ts
+++ b/services/bot/src/lib/security.ts
@@ -1,0 +1,14 @@
+/**
+ * Shared security utilities.
+ */
+
+/**
+ * Escapes special characters for Telegram's Markdown parse mode (legacy).
+ * Use this for all user-generated content inserted into Markdown messages.
+ *
+ * @see https://core.telegram.org/bots/api#markdown-style
+ */
+export function escapeMarkdown(text: string): string {
+  if (!text) return '';
+  return text.replace(/[_*[\]`]/g, '\\$&');
+}


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL/HIGH] Fix IDOR in match viewing and Markdown injection

🚨 Severity: CRITICAL/HIGH
💡 Vulnerability:
1. IDOR: Users could view profiles of users they are not matched with by manipulating callback data.
2. Injection: User names and bios were not escaped in Markdown messages, allowing formatting injection.

🎯 Impact:
1. Unauthorized access to user profile data (location, bio, interests).
2. Potential for broken UI or phishing via Markdown injection.

🔧 Fix:
1. Added `escapeMarkdown` utility in `services/bot/src/lib/security.ts` for legacy Telegram Markdown.
2. Added authorization check in `matchesCallbacks` to verify match existence using `matchService.getMatchList`.
3. Applied `escapeMarkdown` to all user-generated content in `matches.ts`.

✅ Verification:
- Added new test case in `services/bot/src/handlers/matches.test.ts` to verify access denial for unmatched users.
- Updated existing tests to mock match service.
- Ran `bun run test` in `services/bot`: 164 passed.

---
*PR created automatically by Jules for task [12381856701496995965](https://jules.google.com/task/12381856701496995965) started by @irfndi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented access control restricting match profile viewing to confirmed matches only
  * Added sanitization of user-generated content in profiles to prevent injection vulnerabilities

* **Documentation**
  * Added security assessment documentation with identified vulnerabilities and prevention guidance

* **Tests**
  * Enhanced test coverage validating match viewing access control requirements

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->