### PR TITLE
🛡️ Sentinel: Fix IDOR in match viewing and add Markdown escaping

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Insecure Direct Object Reference (IDOR) in `handle_view_match`.
 **Learning:** Checking object ownership is critical even when using hard-to-guess IDs (UUIDs). Defense in depth requires explicit authorization checks.
 **Prevention:** Always verify that the current user is authorized to access the requested resource (e.g., is a participant in the match) before returning sensitive data.
+
+## 2024-05-24 - Markdown Injection & IDOR in Matches
+**Vulnerability:** IDOR in `view_match_user_` callback allowed viewing any user profile. Markdown injection possible in user names/bios.
+**Learning:** Telegram Legacy Markdown requires escaping `_`, `*`, `[`, `` ` ``. Always verify match relationship before showing profile.
+**Prevention:** Use `escapeMarkdown` helper on all user input. Check `matchService` for relationship validity in callbacks.

--- a/services/bot/src/grpc/notificationHandler.ts
+++ b/services/bot/src/grpc/notificationHandler.ts
@@ -6,7 +6,7 @@
  */
 
 import {
-  SendNotificationRequest,
+  type SendNotificationRequest,
   SendNotificationResponse,
 } from '@meetsmatch/contracts/proto/meetsmatch/v1/notification_pb.js';
 import type { Bot } from 'grammy';

--- a/services/bot/src/handlers/matches.test.ts
+++ b/services/bot/src/handlers/matches.test.ts
@@ -137,6 +137,19 @@ describe('Matches List Handler', () => {
     it('should show user profile on view_match_user_', async () => {
       mockCtx.callbackQuery = { data: 'view_match_user_user2' } as any;
 
+      // Mock successful match check
+      const match = createMockMatch({
+        id: 'match1',
+        user1Id: String(mockCtx.from?.id),
+        user2Id: 'user2',
+        status: 'matched',
+        matchedAt: createMockTimestamp(),
+      });
+
+      vi.mocked(matchService.getMatchList).mockReturnValue(
+        Effect.succeed(createGetMatchListResponse([match])),
+      );
+
       const otherUser = createMockUser({
         id: 'user2',
         firstName: 'Jane',
@@ -159,8 +172,78 @@ describe('Matches List Handler', () => {
       );
     });
 
+    it('should deny viewing profile if users are not matched (IDOR protection)', async () => {
+      mockCtx.callbackQuery = { data: 'view_match_user_attacker' } as any;
+
+      // Return match list that does NOT include 'attacker'
+      vi.mocked(matchService.getMatchList).mockReturnValue(
+        Effect.succeed(createGetMatchListResponse([])),
+      );
+
+      await matchesCallbacks(mockCtx as unknown as Context);
+
+      expect(mockCtx.editMessageText).toHaveBeenCalledWith('You are not matched with this user.');
+      expect(userService.getUser).not.toHaveBeenCalled();
+    });
+
+    it('should escape markdown characters in user profile', async () => {
+      mockCtx.callbackQuery = { data: 'view_match_user_user2' } as any;
+
+      // Mock successful match check
+      const match = createMockMatch({
+        id: 'match1',
+        user1Id: String(mockCtx.from?.id),
+        user2Id: 'user2',
+        status: 'matched',
+        matchedAt: createMockTimestamp(),
+      });
+
+      vi.mocked(matchService.getMatchList).mockReturnValue(
+        Effect.succeed(createGetMatchListResponse([match])),
+      );
+
+      const otherUser = createMockUser({
+        id: 'user2',
+        firstName: 'Jane_Doe', // Underscore
+        age: 25,
+        gender: 'female',
+        bio: 'Hello *World*', // Star
+        interests: ['[coding]'], // Brackets
+        location: createMockLocation({ city: 'Seoul', country: 'South Korea' }),
+      });
+
+      vi.mocked(userService.getUser).mockReturnValue(
+        Effect.succeed(createGetUserResponse(otherUser)),
+      );
+
+      await matchesCallbacks(mockCtx as unknown as Context);
+
+      // Verify escaping
+      expect(mockCtx.editMessageText).toHaveBeenCalledWith(
+        expect.stringContaining('Jane\\_Doe'),
+        expect.any(Object),
+      );
+      expect(mockCtx.editMessageText).toHaveBeenCalledWith(
+        expect.stringContaining('Hello \\*World\\*'),
+        expect.any(Object),
+      );
+    });
+
     it("should show not found message if user doesn't exist", async () => {
       mockCtx.callbackQuery = { data: 'view_match_user_unknown' } as any;
+
+      // Mock successful match check
+      const match = createMockMatch({
+        id: 'match1',
+        user1Id: String(mockCtx.from?.id),
+        user2Id: 'unknown',
+        status: 'matched',
+        matchedAt: createMockTimestamp(),
+      });
+
+      vi.mocked(matchService.getMatchList).mockReturnValue(
+        Effect.succeed(createGetMatchListResponse([match])),
+      );
 
       vi.mocked(userService.getUser).mockReturnValue(Effect.succeed(createGetUserResponse(null)));
 
@@ -191,6 +274,19 @@ describe('Matches List Handler', () => {
 
     it('should handle errors gracefully when viewing user', async () => {
       mockCtx.callbackQuery = { data: 'view_match_user_user2' } as any;
+
+      // Mock match check to pass so we can test getUser error
+      const match = createMockMatch({
+        id: 'match1',
+        user1Id: String(mockCtx.from?.id),
+        user2Id: 'user2',
+        status: 'matched',
+        matchedAt: createMockTimestamp(),
+      });
+
+      vi.mocked(matchService.getMatchList).mockReturnValue(
+        Effect.succeed(createGetMatchListResponse([match])),
+      );
 
       vi.mocked(userService.getUser).mockReturnValue(Effect.fail(new Error('Network error')));
 

--- a/services/bot/src/handlers/matches.ts
+++ b/services/bot/src/handlers/matches.ts
@@ -3,6 +3,7 @@ import type { Context } from 'grammy';
 import { InlineKeyboard } from 'grammy';
 
 import { captureEffectError } from '../lib/sentry.js';
+import { escapeMarkdown } from '../lib/security.js';
 import { matchService } from '../services/matchService.js';
 import { userService } from '../services/userService.js';
 import { mainMenuKeyboard } from '../ui/keyboards.js';
@@ -56,7 +57,7 @@ export const matchesCommand = (ctx: Context) =>
         const otherUser = userRes.user;
 
         if (otherUser) {
-          const name = otherUser.firstName || 'Unknown';
+          const name = escapeMarkdown(otherUser.firstName || 'Unknown');
           const age = otherUser.age || '?';
           const matchDate = match.matchedAt
             ? new Date(Number(match.matchedAt.seconds) * 1000).toLocaleDateString()
@@ -135,6 +136,19 @@ export const matchesCallbacks = (ctx: Context) =>
     if (data.startsWith('view_match_user_')) {
       const targetUserId = data.replace('view_match_user_', '');
 
+      // Security check: Verify they are actually matched
+      const matchList = yield* _(matchService.getMatchList(String(ctx.from.id)));
+      const isMatched = (matchList.matches || []).some(
+        (m) => m.user1Id === targetUserId || m.user2Id === targetUserId,
+      );
+
+      if (!isMatched) {
+        yield* _(
+          Effect.tryPromise(() => ctx.editMessageText('You are not matched with this user.')),
+        );
+        return;
+      }
+
       const res = yield* _(userService.getUser(targetUserId));
       const user = res.user;
 
@@ -143,16 +157,16 @@ export const matchesCallbacks = (ctx: Context) =>
         return;
       }
 
-      const interests = user.interests?.join(', ') || 'None';
-      const location = user.location
-        ? `${user.location.city}, ${user.location.country}`
-        : 'Unknown';
+      const interests = escapeMarkdown(user.interests?.join(', ') || 'None');
+      const location = escapeMarkdown(
+        user.location ? `${user.location.city}, ${user.location.country}` : 'Unknown',
+      );
 
       const profileText = `
-👤 *${user.firstName}*, ${user.age || '?'}
-⚧ ${user.gender || 'Unknown'}
+👤 *${escapeMarkdown(user.firstName || 'Unknown')}*, ${user.age || '?'}
+⚧ ${escapeMarkdown(user.gender || 'Unknown')}
 
-📝 ${user.bio || 'No bio'}
+📝 ${escapeMarkdown(user.bio || 'No bio')}
 
 🌟 Interests: ${interests}
 

--- a/services/bot/src/handlers/matches.ts
+++ b/services/bot/src/handlers/matches.ts
@@ -1,9 +1,8 @@
 import { Effect } from 'effect';
 import type { Context } from 'grammy';
 import { InlineKeyboard } from 'grammy';
-
-import { captureEffectError } from '../lib/sentry.js';
 import { escapeMarkdown } from '../lib/security.js';
+import { captureEffectError } from '../lib/sentry.js';
 import { matchService } from '../services/matchService.js';
 import { userService } from '../services/userService.js';
 import { mainMenuKeyboard } from '../ui/keyboards.js';

--- a/services/bot/src/lib/health.test.ts
+++ b/services/bot/src/lib/health.test.ts
@@ -24,19 +24,17 @@ function waitForClose(server: HealthServer['server']): Promise<void> {
   });
 }
 
-// Track port usage to avoid conflicts - use random offset to prevent conflicts between .ts and .js test runs
-const portOffset = Math.floor(Math.random() * 10000);
-let portCounter = 0;
-const getUniquePort = () => 45000 + portOffset + portCounter++;
-
 describe('Health Server', { sequential: true }, () => {
   let healthServer: HealthServer;
   let testPort: number;
 
   beforeEach(async () => {
-    testPort = getUniquePort();
-    healthServer = createHealthServer({ port: testPort, serviceName: 'test-service' });
+    // Use port 0 to let OS assign a random available port
+    healthServer = createHealthServer({ port: 0, serviceName: 'test-service' });
     await waitForServer(healthServer.server);
+    // Get the actual assigned port
+    const address = healthServer.server.address();
+    testPort = typeof address === 'object' && address ? address.port : 0;
   });
 
   afterEach(async () => {
@@ -140,9 +138,10 @@ describe('Health Server', { sequential: true }, () => {
 
   describe('default service name', () => {
     it('should use default service name when not provided', async () => {
-      const defaultPort = getUniquePort();
-      const defaultServer = createHealthServer({ port: defaultPort });
+      const defaultServer = createHealthServer({ port: 0 });
       await waitForServer(defaultServer.server);
+      const address = defaultServer.server.address();
+      const defaultPort = typeof address === 'object' && address ? address.port : 0;
 
       const response = await fetch(`http://localhost:${defaultPort}/health`);
       const body: HealthStatus = await response.json();

--- a/services/bot/src/lib/security.ts
+++ b/services/bot/src/lib/security.ts
@@ -1,0 +1,16 @@
+/**
+ * Security utilities for the bot.
+ */
+
+/**
+ * Escapes special characters for Telegram's legacy Markdown mode.
+ * Characters escaped: _ * ` [
+ */
+export function escapeMarkdown(text: string): string {
+  if (!text) return '';
+  return text
+    .replace(/_/g, '\\_')
+    .replace(/\*/g, '\\*')
+    .replace(/`/g, '\\`')
+    .replace(/\[/g, '\\[');
+}

--- a/services/bot/src/lib/security.ts
+++ b/services/bot/src/lib/security.ts
@@ -8,9 +8,5 @@
  */
 export function escapeMarkdown(text: string): string {
   if (!text) return '';
-  return text
-    .replace(/_/g, '\\_')
-    .replace(/\*/g, '\\*')
-    .replace(/`/g, '\\`')
-    .replace(/\[/g, '\\[');
+  return text.replace(/_/g, '\\_').replace(/\*/g, '\\*').replace(/`/g, '\\`').replace(/\[/g, '\\[');
 }


### PR DESCRIPTION
This PR addresses a High/Critical security issue where users could view any profile by manipulating the callback data in the match view feature (IDOR). It also fixes a potential Denial of Service/UX issue where user names or bios containing special Markdown characters could break message rendering.

Changes:
1.  **Security Utility**: Added `escapeMarkdown` to handle Telegram Legacy Markdown characters (`_`, `*`, `[`, `` ` ``).
2.  **IDOR Fix**: Added a check in `view_match_user_` handler to verify that the `targetUserId` is present in the requesting user's match list.
3.  **Markdown Injection Fix**: Applied `escapeMarkdown` to all user-controlled strings (name, bio, interests, location, gender) before interpolation into Markdown messages.
4.  **Tests**: Added unit tests to `services/bot/src/handlers/matches.test.ts` to verify:
    *   Access is denied when users are not matched.
    *   Special characters are correctly escaped in the output.

---
*PR created automatically by Jules for task [17603284775182380788](https://jules.google.com/task/17603284775182380788) started by @irfndi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unauthorized viewing of other users' profiles and ensured user-facing text is safe from Markdown injection.

* **Tests**
  * Added tests covering access control, markdown-escaping, not-found handling, and error responses for profile viewing.

* **Documentation**
  * Added a new vulnerability entry with learnings and prevention notes related to Markdown escaping and relationship checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->