### PR TITLE
feat(bot): add throttling to activity tracker middleware

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.25.7'
           cache-dependency-path: |
             services/api/go.sum
             packages/contracts/go.sum

--- a/services/bot/src/grpc/notificationHandler.ts
+++ b/services/bot/src/grpc/notificationHandler.ts
@@ -6,7 +6,7 @@
  */
 
 import {
-  SendNotificationRequest,
+  type SendNotificationRequest,
   SendNotificationResponse,
 } from '@meetsmatch/contracts/proto/meetsmatch/v1/notification_pb.js';
 import type { Bot } from 'grammy';

--- a/services/bot/src/lib/activityTracker.test.ts
+++ b/services/bot/src/lib/activityTracker.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Effect } from 'effect';
+import {
+  activityTrackerMiddleware,
+  lastActiveCache,
+  DEBOUNCE_WINDOW_MS,
+  MAX_CACHE_SIZE,
+} from './activityTracker.js';
+import { userService } from '../services/userService.js';
+
+// Mock userService
+vi.mock('../services/userService.js', () => ({
+  userService: {
+    updateLastActive: vi.fn(() => Effect.succeed({ success: true })),
+  },
+}));
+
+describe('activityTrackerMiddleware', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    lastActiveCache.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should call updateLastActive on first interaction and debounce subsequent ones', async () => {
+    const next = vi.fn();
+    const ctx = {
+      from: { id: 12345 },
+    } as any;
+
+    // First call
+    await activityTrackerMiddleware(ctx, next);
+    expect(userService.updateLastActive).toHaveBeenCalledTimes(1);
+    expect(userService.updateLastActive).toHaveBeenCalledWith('12345');
+    expect(lastActiveCache.get('12345')).toBeDefined();
+
+    // Second call immediately after (should be throttled)
+    await activityTrackerMiddleware(ctx, next);
+    expect(userService.updateLastActive).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call updateLastActive again after debounce window expires', async () => {
+    const next = vi.fn();
+    const ctx = {
+      from: { id: 12345 },
+    } as any;
+
+    // First call
+    await activityTrackerMiddleware(ctx, next);
+    expect(userService.updateLastActive).toHaveBeenCalledTimes(1);
+
+    // Advance time by 5 minutes + 1 second
+    vi.advanceTimersByTime(DEBOUNCE_WINDOW_MS + 1000);
+
+    // Call again (should be allowed)
+    await activityTrackerMiddleware(ctx, next);
+    expect(userService.updateLastActive).toHaveBeenCalledTimes(2);
+  });
+
+  it('should track different users independently', async () => {
+    const next = vi.fn();
+    const ctx1 = { from: { id: 12345 } } as any;
+    const ctx2 = { from: { id: 67890 } } as any;
+
+    await activityTrackerMiddleware(ctx1, next);
+    expect(userService.updateLastActive).toHaveBeenCalledWith('12345');
+
+    await activityTrackerMiddleware(ctx2, next);
+    expect(userService.updateLastActive).toHaveBeenCalledWith('67890');
+
+    expect(userService.updateLastActive).toHaveBeenCalledTimes(2);
+  });
+
+  it('should clear cache when size limit is reached', async () => {
+    const next = vi.fn();
+
+    // Fill the cache up to the limit
+    for (let i = 0; i < MAX_CACHE_SIZE; i++) {
+      lastActiveCache.set(`user_${i}`, Date.now());
+    }
+
+    expect(lastActiveCache.size).toBe(MAX_CACHE_SIZE);
+
+    // Next call should trigger clear and add new user
+    const ctx = { from: { id: 999999 } } as any;
+    await activityTrackerMiddleware(ctx, next);
+
+    // Cache should be cleared (size becomes 1 because we just added the new user)
+    expect(lastActiveCache.size).toBe(1);
+    expect(lastActiveCache.has('999999')).toBe(true);
+    expect(userService.updateLastActive).toHaveBeenCalledWith('999999');
+  });
+});

--- a/services/bot/src/lib/activityTracker.test.ts
+++ b/services/bot/src/lib/activityTracker.test.ts
@@ -1,12 +1,12 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Effect } from 'effect';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { userService } from '../services/userService.js';
 import {
   activityTrackerMiddleware,
-  lastActiveCache,
   DEBOUNCE_WINDOW_MS,
+  lastActiveCache,
   MAX_CACHE_SIZE,
 } from './activityTracker.js';
-import { userService } from '../services/userService.js';
 
 // Mock userService
 vi.mock('../services/userService.js', () => ({

--- a/services/bot/src/lib/activityTracker.ts
+++ b/services/bot/src/lib/activityTracker.ts
@@ -10,26 +10,53 @@ import type { MiddlewareFn } from 'grammy';
 import { userService } from '../services/userService.js';
 import type { MyContext } from '../types.js';
 
+// Cache to store the last time a user's activity was updated
+// Key: userId, Value: timestamp (ms)
+// Exported for testing purposes only
+export const lastActiveCache = new Map<string, number>();
+
+// Update last_active at most once every 5 minutes per user
+export const DEBOUNCE_WINDOW_MS = 5 * 60 * 1000;
+
+// Maximum number of users to track in memory to prevent leaks
+export const MAX_CACHE_SIZE = 10000;
+
 /**
  * Middleware that updates user's last_active timestamp on every interaction.
  *
  * This is a fire-and-forget operation - we don't wait for it to complete
  * and errors are silently ignored. This ensures activity tracking doesn't
  * slow down the bot or cause failures.
+ *
+ * Uses an in-memory cache to debounce updates (max once per 5 minutes per user)
+ * to prevent database spamming.
  */
 export const activityTrackerMiddleware: MiddlewareFn<MyContext> = async (ctx, next) => {
   // Only track activity for messages from users (not groups/channels)
   if (ctx.from?.id) {
     const userId = String(ctx.from.id);
+    const now = Date.now();
+    const lastUpdate = lastActiveCache.get(userId);
 
-    // Fire-and-forget: run in the background without waiting
-    Effect.runPromise(
-      userService.updateLastActive(userId).pipe(
-        Effect.catchAll(() => Effect.void), // Silently ignore all errors
-      ),
-    ).catch(() => {
-      // Ignore promise rejection (extra safety)
-    });
+    // Only update if enough time has passed since the last update
+    if (!lastUpdate || now - lastUpdate > DEBOUNCE_WINDOW_MS) {
+      // Prevent memory leaks by clearing cache if it gets too big
+      // A simple clear is sufficient as this is just an optimization cache
+      if (lastActiveCache.size >= MAX_CACHE_SIZE) {
+        lastActiveCache.clear();
+      }
+
+      lastActiveCache.set(userId, now);
+
+      // Fire-and-forget: run in the background without waiting
+      Effect.runPromise(
+        userService.updateLastActive(userId).pipe(
+          Effect.catchAll(() => Effect.void), // Silently ignore all errors
+        ),
+      ).catch(() => {
+        // Ignore promise rejection (extra safety)
+      });
+    }
   }
 
   // Continue to next middleware/handler

--- a/services/bot/src/lib/health.test.ts
+++ b/services/bot/src/lib/health.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { AddressInfo } from 'node:net';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { createHealthServer, type HealthServer, type HealthStatus } from './health.js';
 
 // Helper to wait for server to be listening

--- a/services/bot/src/lib/health.test.ts
+++ b/services/bot/src/lib/health.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { AddressInfo } from 'node:net';
 import { createHealthServer, type HealthServer, type HealthStatus } from './health.js';
 
 // Helper to wait for server to be listening
@@ -24,19 +25,18 @@ function waitForClose(server: HealthServer['server']): Promise<void> {
   });
 }
 
-// Track port usage to avoid conflicts - use random offset to prevent conflicts between .ts and .js test runs
-const portOffset = Math.floor(Math.random() * 10000);
-let portCounter = 0;
-const getUniquePort = () => 45000 + portOffset + portCounter++;
-
 describe('Health Server', { sequential: true }, () => {
   let healthServer: HealthServer;
   let testPort: number;
 
   beforeEach(async () => {
-    testPort = getUniquePort();
-    healthServer = createHealthServer({ port: testPort, serviceName: 'test-service' });
+    // Use port 0 to let the OS assign a random available port
+    healthServer = createHealthServer({ port: 0, serviceName: 'test-service' });
     await waitForServer(healthServer.server);
+
+    // Get the actual assigned port
+    const address = healthServer.server.address() as AddressInfo;
+    testPort = address.port;
   });
 
   afterEach(async () => {
@@ -140,15 +140,19 @@ describe('Health Server', { sequential: true }, () => {
 
   describe('default service name', () => {
     it('should use default service name when not provided', async () => {
-      const defaultPort = getUniquePort();
-      const defaultServer = createHealthServer({ port: defaultPort });
+      // Use port 0 here as well
+      const defaultServer = createHealthServer({ port: 0 });
       await waitForServer(defaultServer.server);
+
+      const address = defaultServer.server.address() as AddressInfo;
+      const defaultPort = address.port;
 
       const response = await fetch(`http://localhost:${defaultPort}/health`);
       const body: HealthStatus = await response.json();
 
       expect(body.service).toBe('meetsmatch-bot');
       defaultServer.stop();
+      await waitForClose(defaultServer.server);
     });
   });
 });


### PR DESCRIPTION
Added throttling to `activityTrackerMiddleware` to prevent database spamming.

- Implemented a 5-minute debounce window using an in-memory `Map`.
- Added a size limit (10,000 entries) to the cache to prevent memory leaks.
- Verified with new unit tests covering throttling, time expiration, and cache clearing.
- Confirmed no regressions by running the full test suite.

---
*PR created automatically by Jules for task [12571549975123802052](https://jules.google.com/task/12571549975123802052) started by @irfndi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Changes

* **Tests**
  * Added comprehensive tests for activity tracking, covering debounce timing, cache behavior, and per-user tracking.

* **Performance**
  * Reduced redundant activity updates via a debounce mechanism.
  * Introduced bounded in-memory cache with automatic eviction to maintain efficiency and limit background update frequency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->