### PR TITLE
🛡️ Sentinel: [HIGH] Fix Telegram Legacy Markdown Injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Insecure Direct Object Reference (IDOR) in `handle_view_match`.
 **Learning:** Checking object ownership is critical even when using hard-to-guess IDs (UUIDs). Defense in depth requires explicit authorization checks.
 **Prevention:** Always verify that the current user is authorized to access the requested resource (e.g., is a participant in the match) before returning sensitive data.
+
+## 2024-06-11 - Telegram Legacy Markdown Injection
+**Vulnerability:** User input was interpolated directly into Telegram messages using `parse_mode: 'Markdown'`, allowing injection of formatting characters (e.g., `_`, `*`, `[`) and potential link spoofing.
+**Learning:** Telegram's legacy Markdown mode is unforgiving and requires escaping specific characters (`_`, `*`, `[`, `` ` ``) to prevent broken formatting and spoofing.
+**Prevention:** Always use an `escapeMarkdown` utility function when displaying user-generated content in Telegram messages.

--- a/services/bot/src/grpc/notificationHandler.ts
+++ b/services/bot/src/grpc/notificationHandler.ts
@@ -6,7 +6,7 @@
  */
 
 import {
-  SendNotificationRequest,
+  type SendNotificationRequest,
   SendNotificationResponse,
 } from '@meetsmatch/contracts/proto/meetsmatch/v1/notification_pb.js';
 import type { Bot } from 'grammy';

--- a/services/bot/src/handlers/match.ts
+++ b/services/bot/src/handlers/match.ts
@@ -2,6 +2,7 @@ import { Effect } from 'effect';
 import type { Context } from 'grammy';
 import { InlineKeyboard } from 'grammy';
 
+import { escapeMarkdown } from '../lib/security.js';
 import { captureEffectError } from '../lib/sentry.js';
 import { matchService } from '../services/matchService.js';
 import { userService } from '../services/userService.js';
@@ -65,17 +66,17 @@ export const matchCommand = (ctx: Context) =>
     }
 
     // 3. Format Message
-    const interests = matchUser.interests.join(', ') || 'None';
+    const interests = matchUser.interests.map(escapeMarkdown).join(', ') || 'None';
     const location = matchUser.location
-      ? `${matchUser.location.city}, ${matchUser.location.country}`
+      ? `${escapeMarkdown(matchUser.location.city)}, ${escapeMarkdown(matchUser.location.country)}`
       : 'Unknown';
 
     const message = MATCH_PROFILE_TEMPLATE(
       // Helper function or string literal
-      matchUser.firstName,
+      escapeMarkdown(matchUser.firstName),
       matchUser.age,
-      matchUser.gender,
-      matchUser.bio || 'No bio',
+      escapeMarkdown(matchUser.gender),
+      escapeMarkdown(matchUser.bio || 'No bio'),
       interests,
       location,
     );
@@ -173,7 +174,7 @@ export const handleLike = (ctx: Context, matchId: string) =>
       // Fetch other user's details to show their name
       const otherUserRes = yield* _(userService.getUser(otherUserId));
       const otherUser = otherUserRes.user;
-      const otherName = otherUser?.firstName || 'your match';
+      const otherName = otherUser?.firstName ? escapeMarkdown(otherUser.firstName) : 'your match';
       const template = getRandomStarter();
 
       yield* _(

--- a/services/bot/src/handlers/matches.ts
+++ b/services/bot/src/handlers/matches.ts
@@ -2,6 +2,7 @@ import { Effect } from 'effect';
 import type { Context } from 'grammy';
 import { InlineKeyboard } from 'grammy';
 
+import { escapeMarkdown } from '../lib/security.js';
 import { captureEffectError } from '../lib/sentry.js';
 import { matchService } from '../services/matchService.js';
 import { userService } from '../services/userService.js';
@@ -56,7 +57,7 @@ export const matchesCommand = (ctx: Context) =>
         const otherUser = userRes.user;
 
         if (otherUser) {
-          const name = otherUser.firstName || 'Unknown';
+          const name = otherUser.firstName ? escapeMarkdown(otherUser.firstName) : 'Unknown';
           const age = otherUser.age || '?';
           const matchDate = match.matchedAt
             ? new Date(Number(match.matchedAt.seconds) * 1000).toLocaleDateString()
@@ -143,16 +144,16 @@ export const matchesCallbacks = (ctx: Context) =>
         return;
       }
 
-      const interests = user.interests?.join(', ') || 'None';
+      const interests = user.interests?.map(escapeMarkdown).join(', ') || 'None';
       const location = user.location
-        ? `${user.location.city}, ${user.location.country}`
+        ? `${escapeMarkdown(user.location.city)}, ${escapeMarkdown(user.location.country)}`
         : 'Unknown';
 
       const profileText = `
-👤 *${user.firstName}*, ${user.age || '?'}
-⚧ ${user.gender || 'Unknown'}
+👤 *${escapeMarkdown(user.firstName || '')}*, ${user.age || '?'}
+⚧ ${escapeMarkdown(user.gender || 'Unknown')}
 
-📝 ${user.bio || 'No bio'}
+📝 ${escapeMarkdown(user.bio || 'No bio')}
 
 🌟 Interests: ${interests}
 

--- a/services/bot/src/handlers/settings.ts
+++ b/services/bot/src/handlers/settings.ts
@@ -2,6 +2,7 @@ import { Effect } from 'effect';
 import type { Context } from 'grammy';
 import { InlineKeyboard } from 'grammy';
 
+import { escapeMarkdown } from '../lib/security.js';
 import { captureEffectError } from '../lib/sentry.js';
 import { userService } from '../services/userService.js';
 
@@ -21,10 +22,10 @@ const formatPreferences = (prefs: any) => {
     lines.push(`📍 Max Distance: ${prefs.maxDistance} km`);
   }
   if (prefs?.genderPreference?.length) {
-    lines.push(`⚧ Looking for: ${prefs.genderPreference.join(', ')}`);
+    lines.push(`⚧ Looking for: ${prefs.genderPreference.map(escapeMarkdown).join(', ')}`);
   }
   if (prefs?.preferredLanguage) {
-    lines.push(`🌐 Language: ${prefs.preferredLanguage}`);
+    lines.push(`🌐 Language: ${escapeMarkdown(prefs.preferredLanguage)}`);
   }
   if (prefs?.notificationsEnabled !== undefined) {
     lines.push(`🔔 Notifications: ${prefs.notificationsEnabled ? 'On' : 'Off'}`);

--- a/services/bot/src/lib/health.test.ts
+++ b/services/bot/src/lib/health.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { createHealthServer, type HealthServer, type HealthStatus } from './health.js';
+import type { AddressInfo } from 'node:net';
 
 // Helper to wait for server to be listening
 function waitForServer(server: HealthServer['server']): Promise<void> {
@@ -24,19 +25,16 @@ function waitForClose(server: HealthServer['server']): Promise<void> {
   });
 }
 
-// Track port usage to avoid conflicts - use random offset to prevent conflicts between .ts and .js test runs
-const portOffset = Math.floor(Math.random() * 10000);
-let portCounter = 0;
-const getUniquePort = () => 45000 + portOffset + portCounter++;
-
 describe('Health Server', { sequential: true }, () => {
   let healthServer: HealthServer;
   let testPort: number;
 
   beforeEach(async () => {
-    testPort = getUniquePort();
-    healthServer = createHealthServer({ port: testPort, serviceName: 'test-service' });
+    // Use port 0 to let OS assign a random available port
+    healthServer = createHealthServer({ port: 0, serviceName: 'test-service' });
     await waitForServer(healthServer.server);
+    const address = healthServer.server.address() as AddressInfo;
+    testPort = address.port;
   });
 
   afterEach(async () => {
@@ -140,15 +138,17 @@ describe('Health Server', { sequential: true }, () => {
 
   describe('default service name', () => {
     it('should use default service name when not provided', async () => {
-      const defaultPort = getUniquePort();
-      const defaultServer = createHealthServer({ port: defaultPort });
+      const defaultServer = createHealthServer({ port: 0 });
       await waitForServer(defaultServer.server);
+      const address = defaultServer.server.address() as AddressInfo;
+      const defaultPort = address.port;
 
       const response = await fetch(`http://localhost:${defaultPort}/health`);
       const body: HealthStatus = await response.json();
 
       expect(body.service).toBe('meetsmatch-bot');
       defaultServer.stop();
+      await waitForClose(defaultServer.server);
     });
   });
 });

--- a/services/bot/src/lib/health.test.ts
+++ b/services/bot/src/lib/health.test.ts
@@ -1,6 +1,6 @@
+import type { AddressInfo } from 'node:net';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { createHealthServer, type HealthServer, type HealthStatus } from './health.js';
-import type { AddressInfo } from 'node:net';
 
 // Helper to wait for server to be listening
 function waitForServer(server: HealthServer['server']): Promise<void> {

--- a/services/bot/src/lib/security.test.ts
+++ b/services/bot/src/lib/security.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { escapeMarkdown } from './security';
+
+describe('escapeMarkdown', () => {
+  it('escapes special characters correctly', () => {
+    expect(escapeMarkdown('hello_world')).toBe('hello\\_world');
+    expect(escapeMarkdown('*bold*')).toBe('\\*bold\\*');
+    expect(escapeMarkdown('[link]')).toBe('\\[link]');
+    expect(escapeMarkdown('code`')).toBe('code\\`');
+  });
+
+  it('handles multiple special characters', () => {
+    expect(escapeMarkdown('hello_world *bold* [link] `code`')).toBe(
+      'hello\\_world \\*bold\\* \\[link] \\`code\\`',
+    );
+  });
+
+  it('handles empty strings', () => {
+    expect(escapeMarkdown('')).toBe('');
+  });
+
+  it('handles strings with no special characters', () => {
+    expect(escapeMarkdown('hello world')).toBe('hello world');
+  });
+
+  it('handles strings with numbers and other symbols', () => {
+    expect(escapeMarkdown('hello 123 !@#$%^&()')).toBe('hello 123 !@#$%^&()');
+  });
+});

--- a/services/bot/src/lib/security.test.ts
+++ b/services/bot/src/lib/security.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { escapeMarkdown } from './security';
+import { escapeMarkdown } from './security.js';
 
 describe('escapeMarkdown', () => {
   it('escapes special characters correctly', () => {

--- a/services/bot/src/lib/security.ts
+++ b/services/bot/src/lib/security.ts
@@ -1,0 +1,15 @@
+/**
+ * Security utilities for the bot service.
+ */
+
+/**
+ * Escapes special characters for Telegram's legacy Markdown format.
+ * Characters `_`, `*`, `[`, `` ` `` must be escaped.
+ *
+ * See: https://core.telegram.org/bots/api#markdown-style
+ */
+export function escapeMarkdown(text: string): string {
+  if (!text) return '';
+  // Characters '_', '*', '[', '`' must be escaped with the preceding character '\'.
+  return text.replace(/_/g, '\\_').replace(/\*/g, '\\*').replace(/\[/g, '\\[').replace(/`/g, '\\`');
+}


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Telegram Legacy Markdown Injection
User-supplied data (names, bios, etc.) was being interpolated directly into Markdown-formatted Telegram messages. This allows users to break message formatting or potentially spoof links.
🎯 Impact: Attackers could inject formatting characters to disrupt the bot's UI or create spoofed links to phishing sites.
🔧 Fix: Implemented `escapeMarkdown` utility to sanitize inputs by escaping `_`, `*`, `[`, and `` ` ``. Applied this sanitizer to all user-generated content displayed in `match.ts`, `matches.ts`, and `settings.ts`.
✅ Verification: Added unit tests in `services/bot/src/lib/security.test.ts` covering all special characters. Ran full test suite to ensure no regressions. verified via `bun run test` in `services/bot`.

---
*PR created automatically by Jules for task [334949434165810077](https://jules.google.com/task/334949434165810077) started by @irfndi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * User-provided text in Telegram messages is now sanitized to prevent formatting problems and spoofed links.

* **Tests**
  * Added unit tests covering the input-sanitization behavior.

* **Chores**
  * Minor import optimizations.
  * Added an advisory entry documenting the Telegram legacy Markdown issue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->