### PR TITLE
⚡ Bolt: Concurrent match profile fetching

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-05-02 - Effect.all Concurrency Defaults
+**Learning:** In `effect` v3, `Effect.all` runs sequentially by default when given an iterable (like an array of Effects). This can silently cause blocking O(n) performance issues if you expect parallel execution.
+**Action:** Always explicitly provide `{ concurrency: 'unbounded' }` (or a specific concurrency limit) to `Effect.all()` when batching concurrent operations to ensure they actually run in parallel.

--- a/services/bot/src/handlers/matches.ts
+++ b/services/bot/src/handlers/matches.ts
@@ -46,34 +46,43 @@ export const matchesCommand = (ctx: Context) =>
     const matchLines: string[] = [];
     const keyboard = new InlineKeyboard();
 
-    for (let i = 0; i < Math.min(matches.length, 10); i++) {
-      const match = matches[i];
-      // Determine the other user's ID
+    const matchesToProcess = matches.slice(0, 10);
+
+    // Optimization: Batch fetch user profiles concurrently instead of sequentially
+    // In Effect v3, Effect.all is sequential for iterables by default, so we must
+    // specify { concurrency: 'unbounded' } to achieve actual parallel requests.
+    const userFetchEffects = matchesToProcess.map((match) => {
       const otherUserId = match.user1Id === userId ? match.user2Id : match.user1Id;
+      return userService.getUser(otherUserId).pipe(
+        Effect.map((res) => ({ match, otherUser: res.user, otherUserId })),
+        Effect.catchAll((e) => {
+          console.error(`Failed to fetch user ${otherUserId}:`, e);
+          return Effect.succeed(null);
+        }),
+      );
+    });
 
-      try {
-        const userRes = yield* _(userService.getUser(otherUserId));
-        const otherUser = userRes.user;
+    const userResults = yield* _(Effect.all(userFetchEffects, { concurrency: 'unbounded' }));
 
-        if (otherUser) {
-          const name = otherUser.firstName || 'Unknown';
-          const age = otherUser.age || '?';
-          const matchDate = match.matchedAt
-            ? new Date(Number(match.matchedAt.seconds) * 1000).toLocaleDateString()
-            : 'Unknown';
+    for (let i = 0; i < userResults.length; i++) {
+      const result = userResults[i];
+      if (!result || !result.otherUser) continue;
 
-          matchLines.push(`${i + 1}. *${name}*, ${age} - matched ${matchDate}`);
+      const { match, otherUser, otherUserId } = result;
 
-          // Add view button for each match
-          if (i % 2 === 0) {
-            keyboard.text(`👤 ${name}`, `view_match_user_${otherUserId}`);
-          } else {
-            keyboard.text(`👤 ${name}`, `view_match_user_${otherUserId}`).row();
-          }
-        }
-      } catch (e) {
-        // Skip if we can't fetch user
-        console.error(`Failed to fetch user ${otherUserId}:`, e);
+      const name = otherUser.firstName || 'Unknown';
+      const age = otherUser.age || '?';
+      const matchDate = match.matchedAt
+        ? new Date(Number(match.matchedAt.seconds) * 1000).toLocaleDateString()
+        : 'Unknown';
+
+      matchLines.push(`${i + 1}. *${name}*, ${age} - matched ${matchDate}`);
+
+      // Add view button for each match
+      if (i % 2 === 0) {
+        keyboard.text(`👤 ${name}`, `view_match_user_${otherUserId}`);
+      } else {
+        keyboard.text(`👤 ${name}`, `view_match_user_${otherUserId}`).row();
       }
     }
 


### PR DESCRIPTION
💡 **What:** Refactored the `matchesCommand` in the bot to fetch user profile details concurrently rather than sequentially.
🎯 **Why:** The previous implementation used a standard `for` loop combined with a yielded effect to fetch user profiles sequentially. This resulted in an N+1 blocking query issue where rendering the matched profiles could take a long time and block the main thread.
📊 **Impact:** Changes the network execution time from O(n) to O(1) concurrent time, significantly improving responsiveness when viewing multiple matches.
🔬 **Measurement:** Verify the improvement by running the bot and invoking the `/matches` command when a user has multiple matches. The list should render noticeably faster, especially on higher-latency networks. Local tests confirm that the behavior and error handling remain functionally correct.

---
*PR created automatically by Jules for task [14964388104054470824](https://jules.google.com/task/14964388104054470824) started by @irfndi*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/irfndi/meets-match/pull/105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

## Summary by Sourcery

Fetch match user profiles concurrently in the matches command to improve responsiveness when listing matches.

Enhancements:
- Limit processed matches to a maximum of 10 and batch their profile fetches using concurrent Effect operations instead of sequential requests.

Documentation:
- Add a Jules bolt note documenting Effect.all’s default sequential behavior and the need to set an explicit concurrency option for parallelism.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced match list performance through parallel user profile requests instead of sequential lookups
  * Improved error handling for user profile fetch failures
  * Match results now limited to the first 10 entries

* **Documentation**
  * Added concurrency handling guidelines

<!-- end of auto-generated comment: release notes by coderabbit.ai -->