### PR TITLE
fix(api): add ConnectRPC handlers and fix SQLite time scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,6 +263,11 @@ jobs:
       - run: npm ci
       - name: Build cf-shared
         run: npx tsc -b packages/cf-shared
+      - name: Apply D1 migrations (dev)
+        run: npx wrangler d1 migrations apply meetsmatch-dev --env dev
+        working-directory: services/cf-bot
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       - name: Deploy cf-api
         run: npx wrangler deploy --env dev
         working-directory: services/cf-api
@@ -294,6 +299,11 @@ jobs:
       - run: npm ci
       - name: Build cf-shared
         run: npx tsc -b packages/cf-shared
+      - name: Apply D1 migrations (prod)
+        run: npx wrangler d1 migrations apply meetsmatch --env production
+        working-directory: services/cf-bot
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       - name: Deploy cf-api (prod)
         run: npx wrangler deploy --env production
         working-directory: services/cf-api

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,30 +110,147 @@ jobs:
       - name: Build
         run: bun run build
 
+  docker-bot:
+    name: Docker Bot Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Set up Buf
+        uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99
+        with:
+          version: '1.47.2'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Docker image
+        run: docker build -t meetsmatch-bot:test .
+
+      - name: Verify container starts without segfault
+        run: |
+          # Start container in background with mock token
+          docker run -d --name test-bot \
+            -e BOT_TOKEN=test:mock_token_for_ci \
+            -p 3000:3000 \
+            meetsmatch-bot:test
+
+          # Wait for container to start
+          sleep 10
+
+          # Get container status and exit code
+          CONTAINER_STATUS=$(docker inspect test-bot --format='{{.State.Status}}' 2>/dev/null || echo "unknown")
+          EXIT_CODE=$(docker inspect test-bot --format='{{.State.ExitCode}}' 2>/dev/null || echo "0")
+
+          echo "Container status: $CONTAINER_STATUS, exit code: $EXIT_CODE"
+
+          # Check for SIGSEGV (exit code 139)
+          if [ "$EXIT_CODE" = "139" ]; then
+            echo "Container crashed with SIGSEGV (exit code 139)"
+            docker logs test-bot 2>&1 || true
+            exit 1
+          fi
+
+          # If container is still running, test health endpoint
+          if [ "$CONTAINER_STATUS" = "running" ]; then
+            echo "Container is running successfully (no segfault)"
+            if curl -f http://localhost:3000/health 2>/dev/null; then
+              echo "Health check passed"
+            else
+              echo "Health endpoint not ready yet"
+            fi
+            docker stop test-bot
+            exit 0
+          fi
+
+          # Container exited - check if it was due to expected bot token error (not SIGSEGV)
+          echo "Container exited with code: $EXIT_CODE"
+          docker logs test-bot 2>&1 | tail -20
+
+          # Exit code 1 is expected (invalid token error), 139 is SIGSEGV failure
+          if [ "$EXIT_CODE" = "1" ]; then
+            # Check if health server started (indicates Bun runtime works)
+            if docker logs test-bot 2>&1 | grep -q "Health server listening"; then
+              echo "Health server started successfully - Bun runtime works correctly"
+              echo "Bot exited due to expected token validation error (not SIGSEGV)"
+              exit 0
+            fi
+          fi
+
+          echo "Unexpected failure"
+          exit 1
+
+  docker-api:
+    name: Docker API Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Build Docker image
+        run: docker build -t meetsmatch-api:test -f services/api/Dockerfile .
+
+      - name: Verify container starts
+        run: |
+          # Start container with minimal config (will fail DB connection but shouldn't crash)
+          docker run -d --name test-api \
+            -e DATABASE_URL=postgres://test:test@localhost:5432/test \
+            -e HTTP_ADDR=:8080 \
+            -p 8080:8080 \
+            meetsmatch-api:test
+
+          # Wait for container to attempt startup
+          sleep 5
+
+          # Check if container is still running (should exit on DB connection failure, not segfault)
+          # Container will likely exit due to no DB, but exit code should not be 139 (SIGSEGV)
+          EXIT_CODE=$(docker inspect test-api --format='{{.State.ExitCode}}' 2>/dev/null || echo "0")
+
+          if [ "$EXIT_CODE" = "139" ]; then
+            echo "Container crashed with SIGSEGV (exit code 139)"
+            docker logs test-api 2>&1 || true
+            exit 1
+          fi
+
+          echo "Container did not segfault (exit code: $EXIT_CODE)"
+          docker logs test-api 2>&1 | tail -20 || true
+          docker rm -f test-api || true
+
   cf-test:
     name: CF Workers (TS)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
+      - name: Check scaffolding exists
+        id: check
+        run: |
+          if [ -f package.json ] && [ -d packages/cf-shared ]; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "CF services not yet scaffolded, skipping"
+          fi
+
       - name: Set up Node.js
+        if: steps.check.outputs.ready == 'true'
         uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7
         with:
           node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies
+        if: steps.check.outputs.ready == 'true'
         run: npm ci
 
       - name: Build (tsc -b)
+        if: steps.check.outputs.ready == 'true'
         run: npx tsc -b packages/cf-shared services/cf-api services/cf-bot services/cf-worker
 
       - name: Test
+        if: steps.check.outputs.ready == 'true'
         run: npm test
 
   cf-deploy-dev:
     name: Deploy CF Workers (dev)
-    if: github.ref == 'refs/heads/main' || (startsWith(github.ref, 'refs/tags/v') && (contains(github.ref, '-pre') || contains(github.ref, '-rc') || contains(github.ref, '-beta')))
+    if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/alpha') || startsWith(github.ref, 'refs/heads/pre-release')) && hashFiles('packages/cf-shared/**') != ''
     needs: [cf-test]
     runs-on: ubuntu-latest
     concurrency: dev-deploy
@@ -144,7 +261,7 @@ jobs:
           node-version: '22'
           cache: 'npm'
       - run: npm ci
-      - name: Deploy cf-shared built output
+      - name: Build cf-shared
         run: npx tsc -b packages/cf-shared
       - name: Deploy cf-api
         run: npx wrangler deploy --env dev
@@ -164,7 +281,7 @@ jobs:
 
   cf-deploy-prod:
     name: Deploy CF Workers (prod)
-    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-pre') && !contains(github.ref, '-rc') && !contains(github.ref, '-beta')
+    if: startsWith(github.ref, 'refs/tags/') && hashFiles('packages/cf-shared/**') != ''
     needs: [cf-test]
     runs-on: ubuntu-latest
     concurrency: prod-deploy
@@ -175,7 +292,7 @@ jobs:
           node-version: '22'
           cache: 'npm'
       - run: npm ci
-      - name: Deploy cf-shared built output
+      - name: Build cf-shared
         run: npx tsc -b packages/cf-shared
       - name: Deploy cf-api (prod)
         run: npx wrangler deploy --env production

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -14,6 +14,10 @@ plugins:
     out: packages/contracts/gen/go
     opt:
       - paths=source_relative
+  - plugin: buf.build/connectrpc/go
+    out: packages/contracts/gen/go
+    opt:
+      - paths=source_relative
   - plugin: buf.build/bufbuild/es:v1.10.0
     out: packages/contracts/gen/ts
     opt:

--- a/packages/cf-shared/src/__tests__/contracts/user.test.ts
+++ b/packages/cf-shared/src/__tests__/contracts/user.test.ts
@@ -16,7 +16,7 @@ import {
 const validUser = {
   id: "user-1",
   username: "johndoe",
-  firstName: "John",
+  displayName: "John",
   lastName: "Doe",
   bio: "Hello world",
   age: 30,
@@ -61,7 +61,7 @@ describe("User Contracts", () => {
       const minimal = { id: "minimal-user" };
       const result = Schema.decodeUnknownSync(User)(minimal);
       expect(result.id).toBe("minimal-user");
-      expect(result.firstName).toBeUndefined();
+      expect(result.displayName).toBeUndefined();
       expect(result.age).toBeUndefined();
     });
 
@@ -199,10 +199,10 @@ describe("User Contracts", () => {
       const result = Schema.decodeUnknownSync(UpdateUserRequest)({
         userId: "abc",
         user: validUser,
-        updateMask: ["firstName", "age"],
+        updateMask: ["displayName", "age"],
       });
       expect(result.userId).toBe("abc");
-      expect(result.updateMask).toEqual(["firstName", "age"]);
+      expect(result.updateMask).toEqual(["displayName", "age"]);
     });
 
     it("should decode UpdateUserRequest without updateMask", () => {

--- a/packages/cf-shared/src/contracts/user.ts
+++ b/packages/cf-shared/src/contracts/user.ts
@@ -34,7 +34,7 @@ export type Preferences = typeof Preferences.Type;
 export const User = Struct({
   id: String,
   username: optional(String),
-  firstName: optional(String),
+  displayName: optional(String),
   lastName: optional(String),
   bio: optional(String),
   age: optional(Number),

--- a/packages/contracts/proto/meetsmatch/v1/notification.proto
+++ b/packages/contracts/proto/meetsmatch/v1/notification.proto
@@ -187,7 +187,7 @@ message SendNotificationResponse {
 // Re-engagement candidate (inactive user eligible for reminder)
 message ReengagementCandidate {
   string user_id = 1;
-  string first_name = 2;
+  string display_name = 2;
   int32 days_inactive = 3;
   int32 pending_likes_count = 4;
   bool notifications_enabled = 5;

--- a/packages/contracts/proto/meetsmatch/v1/user.proto
+++ b/packages/contracts/proto/meetsmatch/v1/user.proto
@@ -21,7 +21,7 @@ service UserService {
 message User {
   string id = 1;
   string username = 2;
-  string first_name = 3;
+  string display_name = 3;
   string last_name = 4;
   string bio = 5;
   int32 age = 6;

--- a/services/api/cmd/api/main.go
+++ b/services/api/cmd/api/main.go
@@ -5,8 +5,10 @@ import (
 	"database/sql"
 	"log"
 	"net"
+	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -15,8 +17,10 @@ import (
 	"github.com/irfndi/match-bot/services/api/internal/config"
 	"github.com/irfndi/match-bot/services/api/internal/grpcserver"
 	"github.com/irfndi/match-bot/services/api/internal/httpserver"
+	"github.com/irfndi/match-bot/services/api/internal/migrate"
 	"github.com/irfndi/match-bot/services/api/internal/notification"
 	sentrypkg "github.com/irfndi/match-bot/services/api/internal/sentry"
+	"github.com/irfndi/match-bot/services/api/internal/services"
 
 	_ "modernc.org/sqlite"
 )
@@ -79,6 +83,18 @@ func main() {
 		time.Sleep(1 * time.Second) // Retry delay between connection attempts
 	}
 
+	migrationsDir := "migrations"
+	if _, err := os.Stat(migrationsDir); os.IsNotExist(err) {
+		migrationsDir = filepath.Join("..", "..", "migrations")
+		if _, err2 := os.Stat(migrationsDir); os.IsNotExist(err2) {
+			migrationsDir = filepath.Join("services", "api", "migrations")
+		}
+	}
+	if err := migrate.Up(db, migrationsDir); err != nil {
+		log.Fatalf("failed to run migrations: %v", err)
+	}
+	logger.Println("Database migrations applied")
+
 	// Initialize notification system (optional - graceful degradation if Redis unavailable)
 	var notificationService *notification.Service
 	var notificationWorker *notification.Worker
@@ -121,16 +137,24 @@ func main() {
 		notificationWorker = notification.NewWorker(notificationService, redisQueue, workerCfg)
 	}
 
-	httpApp := httpserver.New()
+	userSvc := services.NewUserService(db)
+	matchSvc := services.NewMatchService(db)
+
+	httpHandler := httpserver.NewHandler(userSvc, matchSvc)
 	grpcServer := grpcserver.New(db, &grpcserver.Options{
 		NotificationService: notificationService,
 	})
+
+	httpServer := &http.Server{
+		Addr:    cfg.HTTPAddr,
+		Handler: httpHandler,
+	}
 
 	group, groupCtx := errgroup.WithContext(ctx)
 
 	group.Go(func() error {
 		logger.Printf("http listening on %s", cfg.HTTPAddr)
-		if err := httpApp.Listen(cfg.HTTPAddr); err != nil {
+		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			if groupCtx.Err() != nil {
 				return nil
 			}
@@ -181,7 +205,7 @@ func main() {
 		}
 
 		// Shutdown HTTP with timeout
-		if err := httpApp.ShutdownWithContext(shutdownCtx); err != nil {
+		if err := httpServer.Shutdown(shutdownCtx); err != nil {
 			logger.Printf("HTTP shutdown error: %v", err)
 		}
 

--- a/services/api/go.mod
+++ b/services/api/go.mod
@@ -3,6 +3,7 @@ module github.com/irfndi/match-bot/services/api
 go 1.25.9
 
 require (
+	connectrpc.com/connect v1.19.2
 	github.com/getsentry/sentry-go v0.46.2
 	github.com/gofiber/fiber/v2 v2.52.13
 	github.com/google/uuid v1.6.0

--- a/services/api/go.sum
+++ b/services/api/go.sum
@@ -1,3 +1,5 @@
+connectrpc.com/connect v1.19.2 h1:McQ83FGdzL+t60peksi0gXC7MQ/iLKgLduAnThbM0mo=
+connectrpc.com/connect v1.19.2/go.mod h1:tN20fjdGlewnSFeZxLKb0xwIZ6ozc3OQs2hTXy4du9w=
 github.com/andybalholm/brotli v1.2.1 h1:R+f5xP285VArJDRgowrfb9DqL18yVK0gKAW/F+eTWro=
 github.com/andybalholm/brotli v1.2.1/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=

--- a/services/api/internal/httpserver/connect.go
+++ b/services/api/internal/httpserver/connect.go
@@ -1,0 +1,139 @@
+package httpserver
+
+import (
+	"context"
+	"net/http"
+
+	"connectrpc.com/connect"
+	pb "github.com/irfndi/match-bot/packages/contracts/gen/go/proto/meetsmatch/v1"
+	"github.com/irfndi/match-bot/packages/contracts/gen/go/proto/meetsmatch/v1/meetsmatchv1connect"
+	"github.com/irfndi/match-bot/services/api/internal/services"
+)
+
+type userServiceConnectAdapter struct {
+	svc *services.UserService
+}
+
+func (a *userServiceConnectAdapter) GetUser(ctx context.Context, req *connect.Request[pb.GetUserRequest]) (*connect.Response[pb.GetUserResponse], error) {
+	resp, err := a.svc.GetUser(ctx, req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (a *userServiceConnectAdapter) CreateUser(ctx context.Context, req *connect.Request[pb.CreateUserRequest]) (*connect.Response[pb.CreateUserResponse], error) {
+	resp, err := a.svc.CreateUser(ctx, req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (a *userServiceConnectAdapter) UpdateUser(ctx context.Context, req *connect.Request[pb.UpdateUserRequest]) (*connect.Response[pb.UpdateUserResponse], error) {
+	resp, err := a.svc.UpdateUser(ctx, req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (a *userServiceConnectAdapter) UpdateLastActive(ctx context.Context, req *connect.Request[pb.UpdateLastActiveRequest]) (*connect.Response[pb.UpdateLastActiveResponse], error) {
+	resp, err := a.svc.UpdateLastActive(ctx, req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (a *userServiceConnectAdapter) UpdateLastRemindedAt(ctx context.Context, req *connect.Request[pb.UpdateLastRemindedAtRequest]) (*connect.Response[pb.UpdateLastRemindedAtResponse], error) {
+	resp, err := a.svc.UpdateLastRemindedAt(ctx, req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+var _ meetsmatchv1connect.UserServiceHandler = (*userServiceConnectAdapter)(nil)
+
+type matchServiceConnectAdapter struct {
+	svc *services.MatchService
+}
+
+func (a *matchServiceConnectAdapter) GetPotentialMatches(ctx context.Context, req *connect.Request[pb.GetPotentialMatchesRequest]) (*connect.Response[pb.GetPotentialMatchesResponse], error) {
+	resp, err := a.svc.GetPotentialMatches(ctx, req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (a *matchServiceConnectAdapter) LikeMatch(ctx context.Context, req *connect.Request[pb.LikeMatchRequest]) (*connect.Response[pb.LikeMatchResponse], error) {
+	resp, err := a.svc.LikeMatch(ctx, req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (a *matchServiceConnectAdapter) DislikeMatch(ctx context.Context, req *connect.Request[pb.DislikeMatchRequest]) (*connect.Response[pb.DislikeMatchResponse], error) {
+	resp, err := a.svc.DislikeMatch(ctx, req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (a *matchServiceConnectAdapter) SkipMatch(ctx context.Context, req *connect.Request[pb.SkipMatchRequest]) (*connect.Response[pb.SkipMatchResponse], error) {
+	resp, err := a.svc.SkipMatch(ctx, req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (a *matchServiceConnectAdapter) GetMatchList(ctx context.Context, req *connect.Request[pb.GetMatchListRequest]) (*connect.Response[pb.GetMatchListResponse], error) {
+	resp, err := a.svc.GetMatchList(ctx, req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (a *matchServiceConnectAdapter) GetMatch(ctx context.Context, req *connect.Request[pb.GetMatchRequest]) (*connect.Response[pb.GetMatchResponse], error) {
+	resp, err := a.svc.GetMatch(ctx, req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (a *matchServiceConnectAdapter) CreateMatch(ctx context.Context, req *connect.Request[pb.CreateMatchRequest]) (*connect.Response[pb.CreateMatchResponse], error) {
+	resp, err := a.svc.CreateMatch(ctx, req.Msg)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(resp), nil
+}
+
+var _ meetsmatchv1connect.MatchServiceHandler = (*matchServiceConnectAdapter)(nil)
+
+type healthServiceConnectAdapter struct{}
+
+func (a *healthServiceConnectAdapter) Check(ctx context.Context, req *connect.Request[pb.HealthCheckRequest]) (*connect.Response[pb.HealthCheckResponse], error) {
+	return connect.NewResponse(&pb.HealthCheckResponse{Status: "ok"}), nil
+}
+
+var _ meetsmatchv1connect.HealthServiceHandler = (*healthServiceConnectAdapter)(nil)
+
+func registerConnectHandlers(mux *http.ServeMux, userSvc *services.UserService, matchSvc *services.MatchService) {
+	userPath, userHandler := meetsmatchv1connect.NewUserServiceHandler(&userServiceConnectAdapter{svc: userSvc})
+	mux.Handle(userPath, userHandler)
+
+	matchPath, matchHandler := meetsmatchv1connect.NewMatchServiceHandler(&matchServiceConnectAdapter{svc: matchSvc})
+	mux.Handle(matchPath, matchHandler)
+
+	// Health check via ConnectRPC (optional, /health REST endpoint already exists)
+	healthPath, healthHandler := meetsmatchv1connect.NewHealthServiceHandler(&healthServiceConnectAdapter{})
+	mux.Handle(healthPath, healthHandler)
+}

--- a/services/api/internal/httpserver/server.go
+++ b/services/api/internal/httpserver/server.go
@@ -1,26 +1,29 @@
 package httpserver
 
 import (
-	"github.com/gofiber/fiber/v2"
-	sentrypkg "github.com/irfndi/match-bot/services/api/internal/sentry"
+	"net/http"
+
+	"github.com/irfndi/match-bot/services/api/internal/services"
 )
 
-func New() *fiber.App {
-	app := fiber.New()
+func NewHandler(userSvc *services.UserService, matchSvc *services.MatchService) http.Handler {
+	mux := http.NewServeMux()
 
-	// Add Sentry middleware for panic recovery and error capture
-	app.Use(sentrypkg.FiberMiddleware())
+	registerConnectHandlers(mux, userSvc, matchSvc)
 
-	app.Get("/", func(c *fiber.Ctx) error {
-		return c.JSON(fiber.Map{
-			"message":  "MeetMatch API is running",
-			"docs_url": "/docs",
-		})
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"status":"ok"}`))
 	})
 
-	app.Get("/health", func(c *fiber.Ctx) error {
-		return c.JSON(fiber.Map{"status": "ok"})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"message":"MeetMatch API is running","docs_url":"/docs"}`))
 	})
 
-	return app
+	return mux
 }

--- a/services/api/internal/httpserver/server.go
+++ b/services/api/internal/httpserver/server.go
@@ -1,6 +1,7 @@
 package httpserver
 
 import (
+	"log"
 	"net/http"
 
 	"github.com/irfndi/match-bot/services/api/internal/services"
@@ -13,7 +14,9 @@ func NewHandler(userSvc *services.UserService, matchSvc *services.MatchService) 
 
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"status":"ok"}`))
+		if _, err := w.Write([]byte(`{"status":"ok"}`)); err != nil {
+			log.Printf("health write error: %v", err)
+		}
 	})
 
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
@@ -22,7 +25,9 @@ func NewHandler(userSvc *services.UserService, matchSvc *services.MatchService) 
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"message":"MeetMatch API is running","docs_url":"/docs"}`))
+		if _, err := w.Write([]byte(`{"message":"MeetMatch API is running","docs_url":"/docs"}`)); err != nil {
+			log.Printf("root write error: %v", err)
+		}
 	})
 
 	return mux

--- a/services/api/internal/migrate/migrate.go
+++ b/services/api/internal/migrate/migrate.go
@@ -1,0 +1,67 @@
+package migrate
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+func Up(db *sql.DB, migrationsDir string) error {
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS schema_migrations (version TEXT PRIMARY KEY, applied_at TEXT DEFAULT CURRENT_TIMESTAMP)`); err != nil {
+		return fmt.Errorf("create schema_migrations table: %w", err)
+	}
+
+	entries, err := os.ReadDir(migrationsDir)
+	if err != nil {
+		return fmt.Errorf("read migrations dir %s: %w", migrationsDir, err)
+	}
+
+	var files []string
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".up.sql") {
+			files = append(files, e.Name())
+		}
+	}
+	sort.Strings(files)
+
+	for _, name := range files {
+		version := strings.TrimSuffix(name, ".up.sql")
+
+		var exists int
+		if err := db.QueryRow("SELECT COUNT(*) FROM schema_migrations WHERE version = ?", version).Scan(&exists); err != nil {
+			return fmt.Errorf("check migration %s: %w", version, err)
+		}
+		if exists > 0 {
+			continue
+		}
+
+		content, err := os.ReadFile(filepath.Join(migrationsDir, name))
+		if err != nil {
+			return fmt.Errorf("read migration %s: %w", name, err)
+		}
+
+		tx, err := db.Begin()
+		if err != nil {
+			return fmt.Errorf("begin tx for %s: %w", version, err)
+		}
+
+		if _, err := tx.Exec(string(content)); err != nil {
+			tx.Rollback()
+			return fmt.Errorf("apply migration %s: %w", version, err)
+		}
+
+		if _, err := tx.Exec("INSERT INTO schema_migrations (version) VALUES (?)", version); err != nil {
+			tx.Rollback()
+			return fmt.Errorf("record migration %s: %w", version, err)
+		}
+
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("commit migration %s: %w", version, err)
+		}
+	}
+
+	return nil
+}

--- a/services/api/internal/migrate/migrate.go
+++ b/services/api/internal/migrate/migrate.go
@@ -5,9 +5,26 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 )
+
+var versionPattern = regexp.MustCompile(`^[0-9][0-9_]*[a-zA-Z0-9_]+$`)
+
+func validateVersion(version string) error {
+	if !versionPattern.MatchString(version) {
+		return fmt.Errorf("invalid migration version %q: must match pattern like 000001_init_schema", version)
+	}
+	return nil
+}
+
+func validateName(name string) error {
+	if strings.Contains(name, "/") || strings.Contains(name, "\\") || strings.Contains(name, "..") {
+		return fmt.Errorf("invalid migration filename %q", name)
+	}
+	return nil
+}
 
 func Up(db *sql.DB, migrationsDir string) error {
 	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS schema_migrations (version TEXT PRIMARY KEY, applied_at TEXT DEFAULT CURRENT_TIMESTAMP)`); err != nil {
@@ -28,10 +45,16 @@ func Up(db *sql.DB, migrationsDir string) error {
 	sort.Strings(files)
 
 	for _, name := range files {
+		if err := validateName(name); err != nil {
+			return err
+		}
 		version := strings.TrimSuffix(name, ".up.sql")
+		if err := validateVersion(version); err != nil {
+			return err
+		}
 
 		var exists int
-		if err := db.QueryRow("SELECT COUNT(*) FROM schema_migrations WHERE version = ?", version).Scan(&exists); err != nil {
+		if err := db.QueryRow("SELECT COUNT(*) FROM schema_migrations WHERE version = $1", version).Scan(&exists); err != nil {
 			return fmt.Errorf("check migration %s: %w", version, err)
 		}
 		if exists > 0 {
@@ -42,20 +65,24 @@ func Up(db *sql.DB, migrationsDir string) error {
 		if err != nil {
 			return fmt.Errorf("read migration %s: %w", name, err)
 		}
+		sql := strings.TrimSpace(string(content))
+		if sql == "" {
+			return fmt.Errorf("migration %s is empty", name)
+		}
 
 		tx, err := db.Begin()
 		if err != nil {
 			return fmt.Errorf("begin tx for %s: %w", version, err)
 		}
 
-		if _, err := tx.Exec(string(content)); err != nil {
+		if _, err := tx.Exec(sql); err != nil {
 			if rbErr := tx.Rollback(); rbErr != nil {
 				return fmt.Errorf("apply migration %s: %w (rollback: %v)", version, err, rbErr)
 			}
 			return fmt.Errorf("apply migration %s: %w", version, err)
 		}
 
-		if _, err := tx.Exec("INSERT INTO schema_migrations (version) VALUES (?)", version); err != nil {
+		if _, err := tx.Exec("INSERT INTO schema_migrations (version) VALUES ($1)", version); err != nil {
 			if rbErr := tx.Rollback(); rbErr != nil {
 				return fmt.Errorf("record migration %s: %w (rollback: %v)", version, err, rbErr)
 			}

--- a/services/api/internal/migrate/migrate.go
+++ b/services/api/internal/migrate/migrate.go
@@ -49,12 +49,16 @@ func Up(db *sql.DB, migrationsDir string) error {
 		}
 
 		if _, err := tx.Exec(string(content)); err != nil {
-			tx.Rollback()
+			if rbErr := tx.Rollback(); rbErr != nil {
+				return fmt.Errorf("apply migration %s: %w (rollback: %v)", version, err, rbErr)
+			}
 			return fmt.Errorf("apply migration %s: %w", version, err)
 		}
 
 		if _, err := tx.Exec("INSERT INTO schema_migrations (version) VALUES (?)", version); err != nil {
-			tx.Rollback()
+			if rbErr := tx.Rollback(); rbErr != nil {
+				return fmt.Errorf("record migration %s: %w (rollback: %v)", version, err, rbErr)
+			}
 			return fmt.Errorf("record migration %s: %w", version, err)
 		}
 

--- a/services/api/internal/models/match.go
+++ b/services/api/internal/models/match.go
@@ -4,7 +4,6 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"errors"
-	"time"
 )
 
 type MatchStatus string
@@ -51,9 +50,9 @@ type Match struct {
 	User2ID     string       `json:"user2_id"`
 	Status      MatchStatus  `json:"status"`
 	Score       MatchScore   `json:"score"`
-	CreatedAt   time.Time    `json:"created_at"`
-	UpdatedAt   time.Time    `json:"updated_at"`
-	MatchedAt   *time.Time   `json:"matched_at,omitempty"`
+	CreatedAt   SQLiteTime   `json:"created_at"`
+	UpdatedAt   SQLiteTime   `json:"updated_at"`
+	MatchedAt   *SQLiteTime  `json:"matched_at,omitempty"`
 	User1Action *MatchAction `json:"user1_action,omitempty"`
 	User2Action *MatchAction `json:"user2_action,omitempty"`
 }

--- a/services/api/internal/models/user.go
+++ b/services/api/internal/models/user.go
@@ -136,7 +136,7 @@ func (p *Preferences) Scan(value interface{}) error {
 type User struct {
 	ID                string      `json:"id" db:"id"`
 	Username          *string     `json:"username,omitempty" db:"username"`
-	FirstName         string      `json:"first_name" db:"first_name"`
+	DisplayName         string      `json:"first_name" db:"first_name"`
 	LastName          *string     `json:"last_name,omitempty" db:"last_name"`
 	Bio               *string     `json:"bio,omitempty" db:"bio"`
 	Age               *int        `json:"age,omitempty" db:"age"`

--- a/services/api/internal/models/user.go
+++ b/services/api/internal/models/user.go
@@ -1,11 +1,54 @@
 package models
 
 import (
+	"database/sql"
 	"database/sql/driver"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"time"
 )
+
+type SQLiteTime struct{ time.Time }
+
+var _ sql.Scanner = (*SQLiteTime)(nil)
+var _ driver.Valuer = (*SQLiteTime)(nil)
+
+func (st *SQLiteTime) Scan(value interface{}) error {
+	if value == nil {
+		st.Time = time.Time{}
+		return nil
+	}
+	switch v := value.(type) {
+	case time.Time:
+		st.Time = v
+		return nil
+	case string:
+		layouts := []string{
+			"2006-01-02 15:04:05.999999",
+			"2006-01-02 15:04:05",
+			time.RFC3339,
+			time.RFC3339Nano,
+		}
+		for _, layout := range layouts {
+			if t, err := time.Parse(layout, v); err == nil {
+				st.Time = t
+				return nil
+			}
+		}
+		return fmt.Errorf("cannot parse %q as time", v)
+	case []byte:
+		return st.Scan(string(v))
+	}
+	return fmt.Errorf("cannot scan %T into SQLiteTime", value)
+}
+
+func (st SQLiteTime) Value() (driver.Value, error) {
+	if st.Time.IsZero() {
+		return nil, nil
+	}
+	return st.Time.Format("2006-01-02 15:04:05.999999"), nil
+}
 
 type StringArray []string
 
@@ -105,8 +148,8 @@ type User struct {
 	IsActive          bool        `json:"is_active" db:"is_active"`
 	IsSleeping        bool        `json:"is_sleeping" db:"is_sleeping"`
 	IsProfileComplete bool        `json:"is_profile_complete" db:"is_profile_complete"`
-	CreatedAt         time.Time   `json:"created_at" db:"created_at"`
-	UpdatedAt         time.Time   `json:"updated_at" db:"updated_at"`
-	LastActive        time.Time   `json:"last_active" db:"last_active"`
-	LastRemindedAt    *time.Time  `json:"last_reminded_at,omitempty" db:"last_reminded_at"`
+	CreatedAt         SQLiteTime  `json:"created_at" db:"created_at"`
+	UpdatedAt         SQLiteTime  `json:"updated_at" db:"updated_at"`
+	LastActive        SQLiteTime  `json:"last_active" db:"last_active"`
+	LastRemindedAt    *SQLiteTime `json:"last_reminded_at,omitempty" db:"last_reminded_at"`
 }

--- a/services/api/internal/models/user.go
+++ b/services/api/internal/models/user.go
@@ -44,10 +44,10 @@ func (st *SQLiteTime) Scan(value interface{}) error {
 }
 
 func (st SQLiteTime) Value() (driver.Value, error) {
-	if st.Time.IsZero() {
+	if st.IsZero() {
 		return nil, nil
 	}
-	return st.Time.Format("2006-01-02 15:04:05.999999"), nil
+	return st.Format("2006-01-02 15:04:05.999999"), nil
 }
 
 type StringArray []string

--- a/services/api/internal/models/user.go
+++ b/services/api/internal/models/user.go
@@ -136,7 +136,7 @@ func (p *Preferences) Scan(value interface{}) error {
 type User struct {
 	ID                string      `json:"id" db:"id"`
 	Username          *string     `json:"username,omitempty" db:"username"`
-	DisplayName         string      `json:"first_name" db:"first_name"`
+	DisplayName       string      `json:"first_name" db:"first_name"`
 	LastName          *string     `json:"last_name,omitempty" db:"last_name"`
 	Bio               *string     `json:"bio,omitempty" db:"bio"`
 	Age               *int        `json:"age,omitempty" db:"age"`

--- a/services/api/internal/models/user.go
+++ b/services/api/internal/models/user.go
@@ -14,6 +14,13 @@ type SQLiteTime struct{ time.Time }
 var _ sql.Scanner = (*SQLiteTime)(nil)
 var _ driver.Valuer = (*SQLiteTime)(nil)
 
+var timeLayouts = []string{
+	"2006-01-02 15:04:05.999999",
+	"2006-01-02 15:04:05",
+	time.RFC3339,
+	time.RFC3339Nano,
+}
+
 func (st *SQLiteTime) Scan(value interface{}) error {
 	if value == nil {
 		st.Time = time.Time{}
@@ -24,13 +31,7 @@ func (st *SQLiteTime) Scan(value interface{}) error {
 		st.Time = v
 		return nil
 	case string:
-		layouts := []string{
-			"2006-01-02 15:04:05.999999",
-			"2006-01-02 15:04:05",
-			time.RFC3339,
-			time.RFC3339Nano,
-		}
-		for _, layout := range layouts {
+		for _, layout := range timeLayouts {
 			if t, err := time.Parse(layout, v); err == nil {
 				st.Time = t
 				return nil
@@ -47,7 +48,7 @@ func (st SQLiteTime) Value() (driver.Value, error) {
 	if st.IsZero() {
 		return nil, nil
 	}
-	return st.Format("2006-01-02 15:04:05.999999"), nil
+	return st.Format(time.RFC3339Nano), nil
 }
 
 type StringArray []string

--- a/services/api/internal/notification/grpc_service.go
+++ b/services/api/internal/notification/grpc_service.go
@@ -386,7 +386,7 @@ func (s *GRPCService) GetReengagementCandidates(ctx context.Context, req *pb.Get
 
 		err := rows.Scan(
 			&c.UserId,
-			&c.FirstName,
+			&c.DisplayName,
 			&c.DaysInactive,
 			&c.PendingLikesCount,
 			&c.NotificationsEnabled,

--- a/services/api/internal/services/match.go
+++ b/services/api/internal/services/match.go
@@ -321,7 +321,7 @@ func (s *MatchService) CreateMatch(ctx context.Context, req *pb.CreateMatchReque
 
 	// Insert
 	newID := uuid.New().String()
-	now := time.Now()
+	now := time.Now().UTC()
 	nowSQLite := models.SQLiteTime{Time: now}
 
 	query := `
@@ -430,7 +430,7 @@ func (s *MatchService) LikeMatch(ctx context.Context, req *pb.LikeMatchRequest) 
 	// Update action
 	updateQuery := ""
 	isMatch := false
-	now := time.Now()
+	now := time.Now().UTC()
 	nowSQLite := models.SQLiteTime{Time: now}
 
 	if who == 1 {

--- a/services/api/internal/services/match.go
+++ b/services/api/internal/services/match.go
@@ -116,7 +116,7 @@ func (s *MatchService) GetPotentialMatches(ctx context.Context, req *pb.GetPoten
 	for rows.Next() {
 		var u models.User
 		err := rows.Scan(
-			&u.ID, &u.Username, &u.FirstName, &u.LastName, &u.Bio, &u.Age, &u.Gender,
+			&u.ID, &u.Username, &u.DisplayName, &u.LastName, &u.Bio, &u.Age, &u.Gender,
 			&u.Interests, &u.Photos, &u.Location, &u.Preferences,
 			&u.IsActive, &u.IsProfileComplete,
 		)

--- a/services/api/internal/services/match.go
+++ b/services/api/internal/services/match.go
@@ -322,13 +322,14 @@ func (s *MatchService) CreateMatch(ctx context.Context, req *pb.CreateMatchReque
 	// Insert
 	newID := uuid.New().String()
 	now := time.Now()
+	nowSQLite := models.SQLiteTime{Time: now}
 
 	query := `
 		INSERT INTO matches (id, user1_id, user2_id, status, score, created_at, updated_at, user1_action, user2_action)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 	`
 	_, err = s.db.ExecContext(ctx, query,
-		newID, req.User1Id, req.User2Id, "pending", scoreJSON, now, now, "none", "none",
+		newID, req.User1Id, req.User2Id, "pending", scoreJSON, nowSQLite, nowSQLite, "none", "none",
 	)
 
 	if err != nil {
@@ -361,24 +362,36 @@ func (s *MatchService) GetMatch(ctx context.Context, req *pb.GetMatchRequest) (*
 		return nil, status.Errorf(codes.Internal, "failed to get match: %v", err)
 	}
 	if matchedAt.Valid {
-		m.MatchedAt = &matchedAt.Time
+		m.MatchedAt = &models.SQLiteTime{Time: matchedAt.Time}
 	}
+	return s.matchToProto(&m), nil
+}
 
-	// Convert to proto
+func (s *MatchService) matchToProto(m *models.Match) *pb.GetMatchResponse {
+	if m == nil {
+		return nil
+	}
 	pbMatch := &pb.Match{
 		Id:        m.ID,
 		User1Id:   m.User1ID,
 		User2Id:   m.User2ID,
 		Status:    string(m.Status),
 		Score:     m.Score.Total,
-		CreatedAt: timestamppb.New(m.CreatedAt),
-		UpdatedAt: timestamppb.New(m.UpdatedAt),
+		CreatedAt: timestamppb.New(m.CreatedAt.Time),
+		UpdatedAt: timestamppb.New(m.UpdatedAt.Time),
 	}
 	if m.MatchedAt != nil {
-		pbMatch.MatchedAt = timestamppb.New(*m.MatchedAt)
+		pbMatch.MatchedAt = timestamppb.New(m.MatchedAt.Time)
 	}
 
-	return &pb.GetMatchResponse{Match: pbMatch}, nil
+	if m.User1Action != nil {
+		pbMatch.User1Action = string(*m.User1Action)
+	}
+	if m.User2Action != nil {
+		pbMatch.User2Action = string(*m.User2Action)
+	}
+
+	return &pb.GetMatchResponse{Match: pbMatch}
 }
 
 func (s *MatchService) LikeMatch(ctx context.Context, req *pb.LikeMatchRequest) (*pb.LikeMatchResponse, error) {
@@ -413,6 +426,7 @@ func (s *MatchService) LikeMatch(ctx context.Context, req *pb.LikeMatchRequest) 
 	updateQuery := ""
 	isMatch := false
 	now := time.Now()
+	nowSQLite := models.SQLiteTime{Time: now}
 
 	if who == 1 {
 		if act2 == models.MatchActionLike {
@@ -430,7 +444,7 @@ func (s *MatchService) LikeMatch(ctx context.Context, req *pb.LikeMatchRequest) 
 		}
 	}
 
-	_, err = s.db.ExecContext(ctx, updateQuery, req.MatchId, now)
+	_, err = s.db.ExecContext(ctx, updateQuery, req.MatchId, nowSQLite)
 	if err != nil {
 		return nil, err
 	}
@@ -470,14 +484,14 @@ func (s *MatchService) DislikeMatch(ctx context.Context, req *pb.DislikeMatchReq
 	}
 
 	updateQuery := ""
-	now := time.Now()
+	nowSQLite := models.SQLiteTime{Time: time.Now()}
 	if who == 1 {
 		updateQuery = `UPDATE matches SET user1_action='dislike', status='rejected', updated_at=$2 WHERE id=$1`
 	} else {
 		updateQuery = `UPDATE matches SET user2_action='dislike', status='rejected', updated_at=$2 WHERE id=$1`
 	}
 
-	_, err = s.db.ExecContext(ctx, updateQuery, req.MatchId, now)
+	_, err = s.db.ExecContext(ctx, updateQuery, req.MatchId, nowSQLite)
 	if err != nil {
 		return nil, err
 	}
@@ -521,7 +535,7 @@ func (s *MatchService) GetMatchList(ctx context.Context, req *pb.GetMatchListReq
 			continue
 		}
 		if matchedAt.Valid {
-			m.MatchedAt = &matchedAt.Time
+			m.MatchedAt = &models.SQLiteTime{Time: matchedAt.Time}
 		}
 
 		pbMatch := &pb.Match{
@@ -530,11 +544,11 @@ func (s *MatchService) GetMatchList(ctx context.Context, req *pb.GetMatchListReq
 			User2Id:   m.User2ID,
 			Status:    string(m.Status),
 			Score:     m.Score.Total,
-			CreatedAt: timestamppb.New(m.CreatedAt),
-			UpdatedAt: timestamppb.New(m.UpdatedAt),
+			CreatedAt: timestamppb.New(m.CreatedAt.Time),
+			UpdatedAt: timestamppb.New(m.UpdatedAt.Time),
 		}
 		if m.MatchedAt != nil {
-			pbMatch.MatchedAt = timestamppb.New(*m.MatchedAt)
+			pbMatch.MatchedAt = timestamppb.New(m.MatchedAt.Time)
 		}
 		matches = append(matches, pbMatch)
 	}
@@ -574,14 +588,14 @@ func (s *MatchService) SkipMatch(ctx context.Context, req *pb.SkipMatchRequest) 
 	}
 
 	updateQuery := ""
-	now := time.Now()
+	nowSQLite := models.SQLiteTime{Time: time.Now()}
 	if who == 1 {
 		updateQuery = `UPDATE matches SET user1_action='skip', updated_at=$2 WHERE id=$1`
 	} else {
 		updateQuery = `UPDATE matches SET user2_action='skip', updated_at=$2 WHERE id=$1`
 	}
 
-	_, err = s.db.ExecContext(ctx, updateQuery, req.MatchId, now)
+	_, err = s.db.ExecContext(ctx, updateQuery, req.MatchId, nowSQLite)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to skip match: %v", err)
 	}

--- a/services/api/internal/services/match.go
+++ b/services/api/internal/services/match.go
@@ -371,6 +371,13 @@ func (s *MatchService) matchToProto(m *models.Match) *pb.GetMatchResponse {
 	if m == nil {
 		return nil
 	}
+	return &pb.GetMatchResponse{Match: matchModelToProto(m)}
+}
+
+func matchModelToProto(m *models.Match) *pb.Match {
+	if m == nil {
+		return nil
+	}
 	pbMatch := &pb.Match{
 		Id:        m.ID,
 		User1Id:   m.User1ID,
@@ -383,15 +390,13 @@ func (s *MatchService) matchToProto(m *models.Match) *pb.GetMatchResponse {
 	if m.MatchedAt != nil {
 		pbMatch.MatchedAt = timestamppb.New(m.MatchedAt.Time)
 	}
-
 	if m.User1Action != nil {
 		pbMatch.User1Action = string(*m.User1Action)
 	}
 	if m.User2Action != nil {
 		pbMatch.User2Action = string(*m.User2Action)
 	}
-
-	return &pb.GetMatchResponse{Match: pbMatch}
+	return pbMatch
 }
 
 func (s *MatchService) LikeMatch(ctx context.Context, req *pb.LikeMatchRequest) (*pb.LikeMatchResponse, error) {
@@ -538,19 +543,7 @@ func (s *MatchService) GetMatchList(ctx context.Context, req *pb.GetMatchListReq
 			m.MatchedAt = &models.SQLiteTime{Time: matchedAt.Time}
 		}
 
-		pbMatch := &pb.Match{
-			Id:        m.ID,
-			User1Id:   m.User1ID,
-			User2Id:   m.User2ID,
-			Status:    string(m.Status),
-			Score:     m.Score.Total,
-			CreatedAt: timestamppb.New(m.CreatedAt.Time),
-			UpdatedAt: timestamppb.New(m.UpdatedAt.Time),
-		}
-		if m.MatchedAt != nil {
-			pbMatch.MatchedAt = timestamppb.New(m.MatchedAt.Time)
-		}
-		matches = append(matches, pbMatch)
+		matches = append(matches, matchModelToProto(&m))
 	}
 
 	// Check for errors from iterating over rows

--- a/services/api/internal/services/match_test.go
+++ b/services/api/internal/services/match_test.go
@@ -50,11 +50,11 @@ func TestHaversine(t *testing.T) {
 
 func TestCalculateMatchScore_EmptyUsers(t *testing.T) {
 	user1 := &User{
-		ID:        "1",
+		ID:          "1",
 		DisplayName: "Test",
 	}
 	user2 := &User{
-		ID:        "2",
+		ID:          "2",
 		DisplayName: "Test2",
 	}
 
@@ -78,7 +78,7 @@ func TestCalculateMatchScore_EmptyUsers(t *testing.T) {
 func TestCalculateMatchScore_WithLocation(t *testing.T) {
 	maxDist := 20
 	user1 := &User{
-		ID:        "1",
+		ID:          "1",
 		DisplayName: "Test",
 		Location: &Location{
 			Latitude:  37.5665,
@@ -89,7 +89,7 @@ func TestCalculateMatchScore_WithLocation(t *testing.T) {
 		},
 	}
 	user2 := &User{
-		ID:        "2",
+		ID:          "2",
 		DisplayName: "Test2",
 		Location: &Location{
 			Latitude:  37.5700, // ~400m away
@@ -107,14 +107,14 @@ func TestCalculateMatchScore_WithLocation(t *testing.T) {
 
 func TestCalculateMatchScore_WithInterests(t *testing.T) {
 	user1 := &User{
-		ID:        "1",
+		ID:          "1",
 		DisplayName: "Test",
-		Interests: []string{"coding", "coffee", "music"},
+		Interests:   []string{"coding", "coffee", "music"},
 	}
 	user2 := &User{
-		ID:        "2",
+		ID:          "2",
 		DisplayName: "Test2",
-		Interests: []string{"coding", "coffee", "travel"},
+		Interests:   []string{"coding", "coffee", "travel"},
 	}
 
 	score := calculateMatchScore(user1, user2)
@@ -133,7 +133,7 @@ func TestCalculateMatchScore_WithPreferences(t *testing.T) {
 	female := Gender("female")
 
 	user1 := &User{
-		ID:        "1",
+		ID:          "1",
 		DisplayName: "Test",
 		Preferences: Preferences{
 			MinAge:           &minAge,
@@ -142,10 +142,10 @@ func TestCalculateMatchScore_WithPreferences(t *testing.T) {
 		},
 	}
 	user2 := &User{
-		ID:        "2",
+		ID:          "2",
 		DisplayName: "Test2",
-		Age:       &user2Age,
-		Gender:    &male,
+		Age:         &user2Age,
+		Gender:      &male,
 	}
 
 	score := calculateMatchScore(user1, user2)

--- a/services/api/internal/services/match_test.go
+++ b/services/api/internal/services/match_test.go
@@ -51,11 +51,11 @@ func TestHaversine(t *testing.T) {
 func TestCalculateMatchScore_EmptyUsers(t *testing.T) {
 	user1 := &User{
 		ID:        "1",
-		FirstName: "Test",
+		DisplayName: "Test",
 	}
 	user2 := &User{
 		ID:        "2",
-		FirstName: "Test2",
+		DisplayName: "Test2",
 	}
 
 	score := calculateMatchScore(user1, user2)
@@ -79,7 +79,7 @@ func TestCalculateMatchScore_WithLocation(t *testing.T) {
 	maxDist := 20
 	user1 := &User{
 		ID:        "1",
-		FirstName: "Test",
+		DisplayName: "Test",
 		Location: &Location{
 			Latitude:  37.5665,
 			Longitude: 126.9780,
@@ -90,7 +90,7 @@ func TestCalculateMatchScore_WithLocation(t *testing.T) {
 	}
 	user2 := &User{
 		ID:        "2",
-		FirstName: "Test2",
+		DisplayName: "Test2",
 		Location: &Location{
 			Latitude:  37.5700, // ~400m away
 			Longitude: 126.9800,
@@ -108,12 +108,12 @@ func TestCalculateMatchScore_WithLocation(t *testing.T) {
 func TestCalculateMatchScore_WithInterests(t *testing.T) {
 	user1 := &User{
 		ID:        "1",
-		FirstName: "Test",
+		DisplayName: "Test",
 		Interests: []string{"coding", "coffee", "music"},
 	}
 	user2 := &User{
 		ID:        "2",
-		FirstName: "Test2",
+		DisplayName: "Test2",
 		Interests: []string{"coding", "coffee", "travel"},
 	}
 
@@ -134,7 +134,7 @@ func TestCalculateMatchScore_WithPreferences(t *testing.T) {
 
 	user1 := &User{
 		ID:        "1",
-		FirstName: "Test",
+		DisplayName: "Test",
 		Preferences: Preferences{
 			MinAge:           &minAge,
 			MaxAge:           &maxAge,
@@ -143,7 +143,7 @@ func TestCalculateMatchScore_WithPreferences(t *testing.T) {
 	}
 	user2 := &User{
 		ID:        "2",
-		FirstName: "Test2",
+		DisplayName: "Test2",
 		Age:       &user2Age,
 		Gender:    &male,
 	}

--- a/services/api/internal/services/user.go
+++ b/services/api/internal/services/user.go
@@ -298,7 +298,7 @@ func modelToProto(u *models.User) *pb.User {
 
 	pbUser := &pb.User{
 		Id:                u.ID,
-		DisplayName:         u.DisplayName,
+		DisplayName:       u.DisplayName,
 		IsActive:          u.IsActive,
 		IsSleeping:        u.IsSleeping,
 		IsProfileComplete: u.IsProfileComplete,
@@ -383,7 +383,7 @@ func protoToModel(p *pb.User) *models.User {
 
 	u := &models.User{
 		ID:                p.Id,
-		DisplayName:         p.DisplayName,
+		DisplayName:       p.DisplayName,
 		IsActive:          p.IsActive,
 		IsSleeping:        p.IsSleeping,
 		IsProfileComplete: p.IsProfileComplete,

--- a/services/api/internal/services/user.go
+++ b/services/api/internal/services/user.go
@@ -60,7 +60,7 @@ func (s *UserService) CreateUser(ctx context.Context, req *pb.CreateUserRequest)
 	}
 
 	u := protoToModel(req.User)
-	now := time.Now()
+	now := models.SQLiteTime{Time: time.Now()}
 	u.CreatedAt = now
 	u.UpdatedAt = now
 	u.LastActive = now
@@ -302,9 +302,9 @@ func modelToProto(u *models.User) *pb.User {
 		IsActive:          u.IsActive,
 		IsSleeping:        u.IsSleeping,
 		IsProfileComplete: u.IsProfileComplete,
-		CreatedAt:         timestamppb.New(u.CreatedAt),
-		UpdatedAt:         timestamppb.New(u.UpdatedAt),
-		LastActive:        timestamppb.New(u.LastActive),
+		CreatedAt:         timestamppb.New(u.CreatedAt.Time),
+		UpdatedAt:         timestamppb.New(u.UpdatedAt.Time),
+		LastActive:        timestamppb.New(u.LastActive.Time),
 	}
 
 	if u.Username != nil {

--- a/services/api/internal/services/user.go
+++ b/services/api/internal/services/user.go
@@ -60,7 +60,7 @@ func (s *UserService) CreateUser(ctx context.Context, req *pb.CreateUserRequest)
 	}
 
 	u := protoToModel(req.User)
-	now := models.SQLiteTime{Time: time.Now()}
+	now := models.SQLiteTime{Time: time.Now().UTC()}
 	u.CreatedAt = now
 	u.UpdatedAt = now
 	u.LastActive = now

--- a/services/api/internal/services/user.go
+++ b/services/api/internal/services/user.go
@@ -38,7 +38,7 @@ func (s *UserService) GetUser(ctx context.Context, req *pb.GetUserRequest) (*pb.
 
 	var u models.User
 	err := s.db.QueryRowContext(ctx, query, req.UserId).Scan(
-		&u.ID, &u.Username, &u.FirstName, &u.LastName, &u.Bio, &u.Age, &u.Gender,
+		&u.ID, &u.Username, &u.DisplayName, &u.LastName, &u.Bio, &u.Age, &u.Gender,
 		&u.Interests, &u.Photos, &u.Location, &u.Preferences,
 		&u.IsActive, &u.IsSleeping, &u.IsProfileComplete,
 		&u.CreatedAt, &u.UpdatedAt, &u.LastActive,
@@ -82,7 +82,7 @@ func (s *UserService) CreateUser(ctx context.Context, req *pb.CreateUserRequest)
 	`
 
 	_, err = s.db.ExecContext(ctx, query,
-		u.ID, u.Username, u.FirstName, u.LastName, u.Bio, u.Age, u.Gender,
+		u.ID, u.Username, u.DisplayName, u.LastName, u.Bio, u.Age, u.Gender,
 		u.Interests, u.Photos, locJSON, prefJSON,
 		u.IsActive, u.IsSleeping, u.IsProfileComplete,
 		u.CreatedAt, u.UpdatedAt, u.LastActive,
@@ -126,9 +126,9 @@ func (s *UserService) UpdateUser(ctx context.Context, req *pb.UpdateUserRequest)
 	args := []interface{}{}
 	argID := 1
 
-	if uReq.FirstName != "" {
+	if uReq.DisplayName != "" {
 		query += fmt.Sprintf(", first_name = $%d", argID)
-		args = append(args, uReq.FirstName)
+		args = append(args, uReq.DisplayName)
 		argID++
 	}
 	if uReq.Username != nil {
@@ -298,7 +298,7 @@ func modelToProto(u *models.User) *pb.User {
 
 	pbUser := &pb.User{
 		Id:                u.ID,
-		FirstName:         u.FirstName,
+		DisplayName:         u.DisplayName,
 		IsActive:          u.IsActive,
 		IsSleeping:        u.IsSleeping,
 		IsProfileComplete: u.IsProfileComplete,
@@ -383,7 +383,7 @@ func protoToModel(p *pb.User) *models.User {
 
 	u := &models.User{
 		ID:                p.Id,
-		FirstName:         p.FirstName,
+		DisplayName:         p.DisplayName,
 		IsActive:          p.IsActive,
 		IsSleeping:        p.IsSleeping,
 		IsProfileComplete: p.IsProfileComplete,

--- a/services/api/internal/services/user_test.go
+++ b/services/api/internal/services/user_test.go
@@ -51,10 +51,10 @@ func TestUserService_CreateAndGetUser(t *testing.T) {
 	// Create
 	req := &pb.CreateUserRequest{
 		User: &pb.User{
-			Id:        userID,
-			Username:  "testuser",
+			Id:          userID,
+			Username:    "testuser",
 			DisplayName: "Test",
-			LastName:  "User",
+			LastName:    "User",
 		},
 	}
 
@@ -82,7 +82,7 @@ func TestUserService_CreateAndGetUser(t *testing.T) {
 		UserId: userID,
 		User: &pb.User{
 			DisplayName: "UpdatedTest",
-			Bio:       "Updated Bio",
+			Bio:         "Updated Bio",
 		},
 	}
 	updateResp, err := svc.UpdateUser(ctx, updateReq)

--- a/services/api/internal/services/user_test.go
+++ b/services/api/internal/services/user_test.go
@@ -53,7 +53,7 @@ func TestUserService_CreateAndGetUser(t *testing.T) {
 		User: &pb.User{
 			Id:        userID,
 			Username:  "testuser",
-			FirstName: "Test",
+			DisplayName: "Test",
 			LastName:  "User",
 		},
 	}
@@ -73,15 +73,15 @@ func TestUserService_CreateAndGetUser(t *testing.T) {
 		t.Fatalf("GetUser failed: %v", err)
 	}
 
-	if getResp.User.FirstName != "Test" {
-		t.Errorf("Expected FirstName Test, got %s", getResp.User.FirstName)
+	if getResp.User.DisplayName != "Test" {
+		t.Errorf("Expected DisplayName Test, got %s", getResp.User.DisplayName)
 	}
 
 	// Update
 	updateReq := &pb.UpdateUserRequest{
 		UserId: userID,
 		User: &pb.User{
-			FirstName: "UpdatedTest",
+			DisplayName: "UpdatedTest",
 			Bio:       "Updated Bio",
 		},
 	}
@@ -89,8 +89,8 @@ func TestUserService_CreateAndGetUser(t *testing.T) {
 	if err != nil {
 		t.Fatalf("UpdateUser failed: %v", err)
 	}
-	if updateResp.User.FirstName != "UpdatedTest" {
-		t.Errorf("Expected FirstName UpdatedTest, got %s", updateResp.User.FirstName)
+	if updateResp.User.DisplayName != "UpdatedTest" {
+		t.Errorf("Expected DisplayName UpdatedTest, got %s", updateResp.User.DisplayName)
 	}
 
 	// Verify Update

--- a/services/api/migrations/000003_add_notifications.up.sql
+++ b/services/api/migrations/000003_add_notifications.up.sql
@@ -41,7 +41,7 @@ CREATE INDEX IF NOT EXISTS idx_notifications_idempotency ON notifications(idempo
 CREATE INDEX IF NOT EXISTS idx_notifications_related_match ON notifications(related_match_id);
 CREATE INDEX IF NOT EXISTS idx_notifications_related_user ON notifications(related_user_id);
 
-CREATE TABLE IF NOT EXISTS notification_delivery_attempts (
+CREATE TABLE IF NOT EXISTS notification_attempts (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     notification_id TEXT NOT NULL REFERENCES notifications(id) ON DELETE CASCADE,
     attempted_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -52,6 +52,6 @@ CREATE TABLE IF NOT EXISTS notification_delivery_attempts (
     metadata TEXT DEFAULT '{}'
 );
 
-CREATE INDEX IF NOT EXISTS idx_delivery_attempts_notification ON notification_delivery_attempts(notification_id);
-CREATE INDEX IF NOT EXISTS idx_delivery_attempts_status ON notification_delivery_attempts(status);
-CREATE INDEX IF NOT EXISTS idx_delivery_attempts_attempted_at ON notification_delivery_attempts(attempted_at);
+CREATE INDEX IF NOT EXISTS idx_notification_attempts_notification ON notification_attempts(notification_id);
+CREATE INDEX IF NOT EXISTS idx_notification_attempts_status ON notification_attempts(status);
+CREATE INDEX IF NOT EXISTS idx_notification_attempts_attempted_at ON notification_attempts(attempted_at);

--- a/services/api/migrations/000005_rename_first_name_to_display_name.down.sql
+++ b/services/api/migrations/000005_rename_first_name_to_display_name.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users RENAME COLUMN display_name TO first_name;

--- a/services/api/migrations/000005_rename_first_name_to_display_name.up.sql
+++ b/services/api/migrations/000005_rename_first_name_to_display_name.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users RENAME COLUMN first_name TO display_name;

--- a/services/bot/src/__tests__/integration/bot-api.test.ts
+++ b/services/bot/src/__tests__/integration/bot-api.test.ts
@@ -38,7 +38,7 @@ describe.skipIf(skipTests)('Bot-API Integration', () => {
       Effect.either(
         userService.createUser({
           id: TEST_USER_ID,
-          firstName: 'Integration',
+          displayName: 'Integration',
           lastName: 'Test',
           isActive: true,
         }),
@@ -52,7 +52,7 @@ describe.skipIf(skipTests)('Bot-API Integration', () => {
 
     expect(getResult._tag).toBe('Right');
     if (getResult._tag === 'Right') {
-      expect(getResult.right.user?.firstName).toBe('Integration');
+      expect(getResult.right.user?.displayName).toBe('Integration');
     }
   });
 

--- a/services/bot/src/conversations/profile.test.ts
+++ b/services/bot/src/conversations/profile.test.ts
@@ -241,25 +241,20 @@ describe('Profile Conversations', () => {
     });
 
     it('should reject Done with no interests selected', async () => {
-      const replies = [
-        { message: { text: '❌ Done' } },
-        { message: { text: 'Cancel' } },
-      ];
+      const replies = [{ message: { text: '❌ Done' } }, { message: { text: 'Cancel' } }];
       mockConversation = {
         wait: vi.fn().mockImplementation(() => replies.shift() || { message: { text: 'Cancel' } }),
       };
       await editInterests(mockConversation, mockCtx);
       const hasPleaseSelect = mockCtx.reply.mock.calls.some(
-        (call: any[]) => typeof call[0] === 'string' && call[0].includes('Please select at least one interest'),
+        (call: any[]) =>
+          typeof call[0] === 'string' && call[0].includes('Please select at least one interest'),
       );
       expect(hasPleaseSelect).toBe(true);
     });
 
     it('should update interests when selecting and confirming', async () => {
-      const replies = [
-        { message: { text: '🎵 Music' } },
-        { message: { text: '✔️ Done' } },
-      ];
+      const replies = [{ message: { text: '🎵 Music' } }, { message: { text: '✔️ Done' } }];
       mockConversation = {
         wait: vi.fn().mockImplementation(() => replies.shift() || { message: { text: 'Cancel' } }),
         external: vi.fn().mockImplementation((fn) => fn()),

--- a/services/bot/src/conversations/profile.test.ts
+++ b/services/bot/src/conversations/profile.test.ts
@@ -1,4 +1,4 @@
-import { Either } from 'effect';
+import { Effect, Either } from 'effect';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock userService before importing
@@ -29,16 +29,9 @@ describe('Profile Conversations', () => {
         wait: vi.fn().mockResolvedValue({ message: { text: 'My new bio' } }),
         external: vi.fn().mockImplementation((fn) => fn()),
       };
-
-      vi.mocked(userService.updateUser).mockReturnValue({
-        pipe: () => Either.right({ user: {} }),
-      } as any);
-
-      // Mock Effect.either to return Right
+      vi.mocked(userService.updateUser).mockReturnValue(Effect.succeed({ user: {} }) as any);
       mockConversation.external.mockResolvedValue(Either.right({ user: {} }));
-
       await editBio(mockConversation, mockCtx);
-
       expect(mockCtx.reply).toHaveBeenCalledWith(
         expect.stringContaining('Bio updated'),
         expect.any(Object),
@@ -47,12 +40,8 @@ describe('Profile Conversations', () => {
 
     it('should reject bio exceeding 300 characters', async () => {
       const longBio = 'a'.repeat(301);
-      mockConversation = {
-        wait: vi.fn().mockResolvedValue({ message: { text: longBio } }),
-      };
-
+      mockConversation = { wait: vi.fn().mockResolvedValue({ message: { text: longBio } }) };
       await editBio(mockConversation, mockCtx);
-
       expect(mockCtx.reply).toHaveBeenCalledWith(
         expect.stringContaining('Bio is too long'),
         expect.any(Object),
@@ -60,48 +49,47 @@ describe('Profile Conversations', () => {
     });
 
     it('should handle cancel', async () => {
-      mockConversation = {
-        wait: vi.fn().mockResolvedValue({ message: { text: 'Cancel' } }),
-      };
-
+      mockConversation = { wait: vi.fn().mockResolvedValue({ message: { text: 'Cancel' } }) };
       await editBio(mockConversation, mockCtx);
-
       expect(mockCtx.reply).toHaveBeenCalledWith('Cancelled.', expect.any(Object));
     });
 
     it('should handle empty message', async () => {
-      mockConversation = {
-        wait: vi.fn().mockResolvedValue({ message: null }),
-      };
-
+      mockConversation = { wait: vi.fn().mockResolvedValue({ message: null }) };
       await editBio(mockConversation, mockCtx);
-
       expect(mockCtx.reply).toHaveBeenCalledWith('Cancelled.', expect.any(Object));
     });
 
     it('should handle API failure', async () => {
       mockConversation = {
         wait: vi.fn().mockResolvedValue({ message: { text: 'Valid bio' } }),
-        external: vi.fn().mockResolvedValue(Either.left(new Error('API error'))),
+        external: vi.fn().mockResolvedValue(Either.left(new Error('err'))),
       };
-
       await editBio(mockConversation, mockCtx);
-
       expect(mockCtx.reply).toHaveBeenCalledWith(
-        expect.stringContaining('Failed to update bio'),
+        expect.stringContaining('Failed'),
         expect.any(Object),
       );
     });
   });
 
   describe('editAge', () => {
-    it('should reject age below 18', async () => {
+    it('should accept valid age', async () => {
       mockConversation = {
-        wait: vi.fn().mockResolvedValue({ message: { text: '17' } }),
+        wait: vi.fn().mockResolvedValue({ message: { text: '25' } }),
+        external: vi.fn().mockImplementation((fn) => fn()),
       };
-
+      vi.mocked(userService.updateUser).mockReturnValue(Effect.succeed({ user: {} }) as any);
       await editAge(mockConversation, mockCtx);
+      expect(mockCtx.reply).toHaveBeenCalledWith(
+        expect.stringContaining('Age updated'),
+        expect.any(Object),
+      );
+    });
 
+    it('should reject age below 18', async () => {
+      mockConversation = { wait: vi.fn().mockResolvedValue({ message: { text: '17' } }) };
+      await editAge(mockConversation, mockCtx);
       expect(mockCtx.reply).toHaveBeenCalledWith(
         expect.stringContaining('Invalid age'),
         expect.any(Object),
@@ -109,12 +97,8 @@ describe('Profile Conversations', () => {
     });
 
     it('should reject age above 65', async () => {
-      mockConversation = {
-        wait: vi.fn().mockResolvedValue({ message: { text: '66' } }),
-      };
-
+      mockConversation = { wait: vi.fn().mockResolvedValue({ message: { text: '66' } }) };
       await editAge(mockConversation, mockCtx);
-
       expect(mockCtx.reply).toHaveBeenCalledWith(
         expect.stringContaining('Invalid age'),
         expect.any(Object),
@@ -122,12 +106,8 @@ describe('Profile Conversations', () => {
     });
 
     it('should reject non-numeric input', async () => {
-      mockConversation = {
-        wait: vi.fn().mockResolvedValue({ message: { text: 'abc' } }),
-      };
-
+      mockConversation = { wait: vi.fn().mockResolvedValue({ message: { text: 'abc' } }) };
       await editAge(mockConversation, mockCtx);
-
       expect(mockCtx.reply).toHaveBeenCalledWith(
         expect.stringContaining('Invalid age'),
         expect.any(Object),
@@ -137,11 +117,10 @@ describe('Profile Conversations', () => {
     it('should accept valid age at lower bound', async () => {
       mockConversation = {
         wait: vi.fn().mockResolvedValue({ message: { text: '18' } }),
-        external: vi.fn().mockResolvedValue(Either.right({ user: {} })),
+        external: vi.fn().mockImplementation((fn) => fn()),
       };
-
+      vi.mocked(userService.updateUser).mockReturnValue(Effect.succeed({ user: {} }) as any);
       await editAge(mockConversation, mockCtx);
-
       expect(mockCtx.reply).toHaveBeenCalledWith(
         expect.stringContaining('Age updated to 18'),
         expect.any(Object),
@@ -151,11 +130,10 @@ describe('Profile Conversations', () => {
     it('should accept valid age at upper bound', async () => {
       mockConversation = {
         wait: vi.fn().mockResolvedValue({ message: { text: '65' } }),
-        external: vi.fn().mockResolvedValue(Either.right({ user: {} })),
+        external: vi.fn().mockImplementation((fn) => fn()),
       };
-
+      vi.mocked(userService.updateUser).mockReturnValue(Effect.succeed({ user: {} }) as any);
       await editAge(mockConversation, mockCtx);
-
       expect(mockCtx.reply).toHaveBeenCalledWith(
         expect.stringContaining('Age updated to 65'),
         expect.any(Object),
@@ -163,12 +141,8 @@ describe('Profile Conversations', () => {
     });
 
     it('should handle cancel', async () => {
-      mockConversation = {
-        wait: vi.fn().mockResolvedValue({ message: { text: 'Cancel' } }),
-      };
-
+      mockConversation = { wait: vi.fn().mockResolvedValue({ message: { text: 'Cancel' } }) };
       await editAge(mockConversation, mockCtx);
-
       expect(mockCtx.reply).toHaveBeenCalledWith('Cancelled.', expect.any(Object));
     });
   });
@@ -177,37 +151,25 @@ describe('Profile Conversations', () => {
     it('should update name successfully', async () => {
       mockConversation = {
         wait: vi.fn().mockResolvedValue({ message: { text: 'John' } }),
-        external: vi.fn().mockResolvedValue(Either.right({ user: {} })),
+        external: vi.fn().mockImplementation((fn) => fn()),
       };
-
+      vi.mocked(userService.updateUser).mockReturnValue(Effect.succeed({ user: {} }) as any);
       await editName(mockConversation, mockCtx);
-
       expect(mockCtx.reply).toHaveBeenCalledWith(
-        expect.stringContaining('Name updated to John'),
+        expect.stringContaining('Name updated to'),
         expect.any(Object),
       );
     });
 
-    it('should reject empty name', async () => {
-      mockConversation = {
-        wait: vi.fn().mockResolvedValue({ message: { text: '   ' } }),
-      };
-
+    it('should cancel on empty name', async () => {
+      mockConversation = { wait: vi.fn().mockResolvedValue({ message: { text: '' } }) };
       await editName(mockConversation, mockCtx);
-
-      expect(mockCtx.reply).toHaveBeenCalledWith(
-        expect.stringContaining('Name must be 1-50 characters'),
-        expect.any(Object),
-      );
+      expect(mockCtx.reply).toHaveBeenCalledWith('Cancelled.', expect.any(Object));
     });
 
     it('should reject name longer than 50 characters', async () => {
-      mockConversation = {
-        wait: vi.fn().mockResolvedValue({ message: { text: 'a'.repeat(51) } }),
-      };
-
+      mockConversation = { wait: vi.fn().mockResolvedValue({ message: { text: 'a'.repeat(51) } }) };
       await editName(mockConversation, mockCtx);
-
       expect(mockCtx.reply).toHaveBeenCalledWith(
         expect.stringContaining('Name must be 1-50 characters'),
         expect.any(Object),
@@ -215,14 +177,12 @@ describe('Profile Conversations', () => {
     });
 
     it('should accept name at exactly 50 characters', async () => {
-      const name50 = 'a'.repeat(50);
       mockConversation = {
-        wait: vi.fn().mockResolvedValue({ message: { text: name50 } }),
-        external: vi.fn().mockResolvedValue(Either.right({ user: {} })),
+        wait: vi.fn().mockResolvedValue({ message: { text: 'a'.repeat(50) } }),
+        external: vi.fn().mockImplementation((fn) => fn()),
       };
-
+      vi.mocked(userService.updateUser).mockReturnValue(Effect.succeed({ user: {} }) as any);
       await editName(mockConversation, mockCtx);
-
       expect(mockCtx.reply).toHaveBeenCalledWith(
         expect.stringContaining('Name updated to'),
         expect.any(Object),
@@ -234,11 +194,10 @@ describe('Profile Conversations', () => {
     it('should update gender to Male', async () => {
       mockConversation = {
         wait: vi.fn().mockResolvedValue({ message: { text: 'Male' } }),
-        external: vi.fn().mockResolvedValue(Either.right({ user: {} })),
+        external: vi.fn().mockImplementation((fn) => fn()),
       };
-
+      vi.mocked(userService.updateUser).mockReturnValue(Effect.succeed({ user: {} }) as any);
       await editGender(mockConversation, mockCtx);
-
       expect(mockCtx.reply).toHaveBeenCalledWith(
         expect.stringContaining('Gender updated to Male'),
         expect.any(Object),
@@ -248,11 +207,10 @@ describe('Profile Conversations', () => {
     it('should update gender to Female', async () => {
       mockConversation = {
         wait: vi.fn().mockResolvedValue({ message: { text: 'Female' } }),
-        external: vi.fn().mockResolvedValue(Either.right({ user: {} })),
+        external: vi.fn().mockImplementation((fn) => fn()),
       };
-
+      vi.mocked(userService.updateUser).mockReturnValue(Effect.succeed({ user: {} }) as any);
       await editGender(mockConversation, mockCtx);
-
       expect(mockCtx.reply).toHaveBeenCalledWith(
         expect.stringContaining('Gender updated to Female'),
         expect.any(Object),
@@ -260,12 +218,8 @@ describe('Profile Conversations', () => {
     });
 
     it('should reject invalid gender selection', async () => {
-      mockConversation = {
-        wait: vi.fn().mockResolvedValue({ message: { text: 'Other' } }),
-      };
-
+      mockConversation = { wait: vi.fn().mockResolvedValue({ message: { text: 'Other' } }) };
       await editGender(mockConversation, mockCtx);
-
       expect(mockCtx.reply).toHaveBeenCalledWith(
         expect.stringContaining('Invalid selection'),
         expect.any(Object),
@@ -273,141 +227,93 @@ describe('Profile Conversations', () => {
     });
 
     it('should handle cancel', async () => {
-      mockConversation = {
-        wait: vi.fn().mockResolvedValue({ message: { text: 'Cancel' } }),
-      };
-
+      mockConversation = { wait: vi.fn().mockResolvedValue({ message: { text: 'Cancel' } }) };
       await editGender(mockConversation, mockCtx);
-
       expect(mockCtx.reply).toHaveBeenCalledWith('Cancelled.', expect.any(Object));
     });
   });
 
   describe('editInterests', () => {
-    it('should update interests successfully', async () => {
-      mockConversation = {
-        wait: vi.fn().mockResolvedValue({ message: { text: 'coding, music, travel' } }),
-        external: vi.fn().mockResolvedValue(Either.right({ user: {} })),
-      };
-
+    it('should handle cancel immediately', async () => {
+      mockConversation = { wait: vi.fn().mockResolvedValue({ message: { text: 'Cancel' } }) };
       await editInterests(mockConversation, mockCtx);
-
-      expect(mockCtx.reply).toHaveBeenCalledWith(
-        expect.stringContaining('Interests updated: coding, music, travel'),
-        expect.any(Object),
-      );
+      expect(mockCtx.reply).toHaveBeenCalledWith('Cancelled.', expect.any(Object));
     });
 
-    it('should limit to 10 interests', async () => {
-      const manyInterests = Array(15)
-        .fill(0)
-        .map((_, i) => `interest${i}`)
-        .join(', ');
+    it('should reject Done with no interests selected', async () => {
+      const replies = [
+        { message: { text: '❌ Done' } },
+        { message: { text: 'Cancel' } },
+      ];
       mockConversation = {
-        wait: vi.fn().mockResolvedValue({ message: { text: manyInterests } }),
-        external: vi.fn().mockResolvedValue(Either.right({ user: {} })),
+        wait: vi.fn().mockImplementation(() => replies.shift() || { message: { text: 'Cancel' } }),
       };
-
       await editInterests(mockConversation, mockCtx);
-
-      // Should only include first 10
-      expect(mockCtx.reply).toHaveBeenCalledWith(
-        expect.stringContaining('Interests updated'),
-        expect.any(Object),
+      const hasPleaseSelect = mockCtx.reply.mock.calls.some(
+        (call: any[]) => typeof call[0] === 'string' && call[0].includes('Please select at least one interest'),
       );
+      expect(hasPleaseSelect).toBe(true);
     });
 
-    it('should reject empty interests', async () => {
+    it('should update interests when selecting and confirming', async () => {
+      const replies = [
+        { message: { text: '🎵 Music' } },
+        { message: { text: '✔️ Done' } },
+      ];
       mockConversation = {
-        wait: vi.fn().mockResolvedValue({ message: { text: ',,,,' } }),
+        wait: vi.fn().mockImplementation(() => replies.shift() || { message: { text: 'Cancel' } }),
+        external: vi.fn().mockImplementation((fn) => fn()),
       };
-
+      vi.mocked(userService.updateUser).mockReturnValue(Effect.succeed({ user: {} }) as any);
       await editInterests(mockConversation, mockCtx);
-
-      expect(mockCtx.reply).toHaveBeenCalledWith(
-        expect.stringContaining('Please provide at least one interest'),
-        expect.any(Object),
+      const hasInterestsUpdated = mockCtx.reply.mock.calls.some(
+        (call: any[]) => typeof call[0] === 'string' && call[0].includes('Interests updated'),
       );
-    });
-
-    it('should normalize interests to lowercase', async () => {
-      mockConversation = {
-        wait: vi.fn().mockResolvedValue({ message: { text: 'CODING, Music, TrAvEl' } }),
-        external: vi.fn().mockResolvedValue(Either.right({ user: {} })),
-      };
-
-      await editInterests(mockConversation, mockCtx);
-
-      expect(mockCtx.reply).toHaveBeenCalledWith(
-        expect.stringContaining('coding, music, travel'),
-        expect.any(Object),
-      );
+      expect(hasInterestsUpdated).toBe(true);
     });
   });
 
   describe('editLocation', () => {
-    it('should update location with GPS coordinates', async () => {
+    it('should update location with GPS', async () => {
       mockConversation = {
         wait: vi.fn().mockResolvedValue({
           message: { location: { latitude: 37.5665, longitude: 126.978 } },
         }),
-        external: vi.fn().mockResolvedValue(Either.right({ user: {} })),
+        external: vi.fn().mockImplementation((fn) => fn()),
       };
-
+      vi.mocked(userService.updateUser).mockReturnValue(Effect.succeed({ user: {} }) as any);
       await editLocation(mockConversation, mockCtx);
-
-      expect(mockCtx.reply).toHaveBeenCalledWith(
-        expect.stringMatching(/Location updated to.*37\.5665.*126\.9780/),
-        expect.any(Object),
+      const hasLocationUpdated = mockCtx.reply.mock.calls.some(
+        (call: any[]) => typeof call[0] === 'string' && call[0].includes('Location updated'),
       );
+      expect(hasLocationUpdated).toBe(true);
     });
 
-    it('should update location with text input', async () => {
-      mockConversation = {
-        wait: vi.fn().mockResolvedValue({ message: { text: 'Seoul, South Korea' } }),
-        external: vi.fn().mockResolvedValue(Either.right({ user: {} })),
-      };
-
+    it('should reject text input', async () => {
+      mockConversation = { wait: vi.fn().mockResolvedValue({ message: { text: 'Seoul' } }) };
       await editLocation(mockConversation, mockCtx);
-
       expect(mockCtx.reply).toHaveBeenCalledWith(
-        expect.stringContaining('Location updated to Seoul, South Korea'),
-        expect.any(Object),
-      );
-    });
-
-    it('should reject invalid location format', async () => {
-      mockConversation = {
-        wait: vi.fn().mockResolvedValue({ message: { text: 'InvalidLocation' } }),
-      };
-
-      await editLocation(mockConversation, mockCtx);
-
-      expect(mockCtx.reply).toHaveBeenCalledWith(
-        expect.stringContaining('Please use format: City, Country'),
+        expect.stringContaining('Please share your location'),
         expect.any(Object),
       );
     });
 
     it('should handle cancel', async () => {
-      mockConversation = {
-        wait: vi.fn().mockResolvedValue({ message: { text: 'Cancel' } }),
-      };
-
+      mockConversation = { wait: vi.fn().mockResolvedValue({ message: { text: 'Cancel' } }) };
       await editLocation(mockConversation, mockCtx);
-
       expect(mockCtx.reply).toHaveBeenCalledWith('Cancelled.', expect.any(Object));
     });
 
-    it('should handle missing message', async () => {
+    it('should handle API failure', async () => {
       mockConversation = {
-        wait: vi.fn().mockResolvedValue({ message: null }),
+        wait: vi.fn().mockResolvedValue({
+          message: { location: { latitude: 37.5, longitude: 127.0 } },
+        }),
+        external: vi.fn().mockResolvedValue(Either.left(new Error('err'))),
       };
-
       await editLocation(mockConversation, mockCtx);
-
       expect(mockCtx.reply).toHaveBeenCalledWith(
-        expect.stringContaining('Invalid input'),
+        expect.stringContaining('Failed'),
         expect.any(Object),
       );
     });

--- a/services/bot/src/conversations/profile.ts
+++ b/services/bot/src/conversations/profile.ts
@@ -102,7 +102,7 @@ export async function editName(conversation: Conversation<MyContext, MyContext>,
   const userId = String(ctx.from?.id);
 
   const result = await conversation.external(() =>
-    Effect.runPromise(Effect.either(userService.updateUser(userId, { firstName: name }))),
+    Effect.runPromise(Effect.either(userService.updateUser(userId, { displayName: name }))),
   );
 
   if (result._tag === 'Left') {

--- a/services/bot/src/conversations/profile.ts
+++ b/services/bot/src/conversations/profile.ts
@@ -81,7 +81,7 @@ export async function editAge(conversation: Conversation<MyContext, MyContext>, 
 
 // === NAME CONVERSATION ===
 export async function editName(conversation: Conversation<MyContext, MyContext>, ctx: MyContext) {
-  await ctx.reply('Please enter your first name:', {
+  await ctx.reply('What name should other users see?', {
     reply_markup: new Keyboard().text('Cancel').resized().oneTime(),
   });
   const { message } = await conversation.wait();
@@ -168,39 +168,116 @@ export async function editGender(conversation: Conversation<MyContext, MyContext
 }
 
 // === INTERESTS CONVERSATION ===
+
+const PREDEFINED_INTERESTS = [
+  '🎵 Music',
+  '🎬 Movies',
+  '📚 Books',
+  '☕ Coffee',
+  '🍳 Cooking',
+  '✈️ Travel',
+  '🏋️ Fitness',
+  '🎮 Gaming',
+  '📸 Photography',
+  '🐾 Pets',
+  '🌿 Nature',
+  '💻 Tech',
+  '🎨 Art',
+  '⚽ Sports',
+  '🧘 Yoga',
+  '💃 Dancing',
+];
+
+function buildInterestsKeyboard(selected: Set<string>): Keyboard {
+  const kb = new Keyboard();
+
+  for (let i = 0; i < PREDEFINED_INTERESTS.length; i++) {
+    const interest = PREDEFINED_INTERESTS[i];
+    const label = selected.has(interest) ? `✅ ${interest}` : interest;
+    kb.text(label);
+    if ((i + 1) % 3 === 0) kb.row();
+  }
+  kb.row();
+  kb.text('➕ Add Custom').row();
+  kb.text(selected.size > 0 ? '✔️ Done' : '❌ Done');
+  kb.text('Cancel').resized();
+
+  return kb;
+}
+
+function interestLabelToValue(label: string): string {
+  return label.replace(/^[✅➕✔️❌]\s*/, '').toLowerCase();
+}
+
 export async function editInterests(
   conversation: Conversation<MyContext, MyContext>,
   ctx: MyContext,
 ) {
-  await ctx.reply(
-    'Enter your interests, separated by commas (max 10):\n\nExample: coding, coffee, travel, music',
-    {
-      reply_markup: new Keyboard().text('Cancel').resized().oneTime(),
-    },
-  );
+  const selected = new Set<string>();
 
-  const { message } = await conversation.wait();
+  await ctx.reply('Choose your interests (at least 1):', {
+    reply_markup: buildInterestsKeyboard(selected).oneTime(),
+  });
 
-  if (!message?.text || message.text === 'Cancel') {
-    await ctx.reply('Cancelled.', { reply_markup: { remove_keyboard: true } });
-    return;
-  }
+  let iterations = 0;
+  while (iterations < 50) {
+    iterations++;
+    const { message } = await conversation.wait();
 
-  const interests = message.text
-    .split(',')
-    .map((i) => i.trim().toLowerCase())
-    .filter((i) => i.length > 0)
-    .slice(0, 10);
+    if (!message?.text) continue;
 
-  if (interests.length === 0) {
-    await ctx.reply('Please provide at least one interest. Cancelled.', {
-      reply_markup: { remove_keyboard: true },
+    const text = message.text;
+
+    if (text === 'Cancel') {
+      await ctx.reply('Cancelled.', { reply_markup: { remove_keyboard: true } });
+      return;
+    }
+
+    if (text === '❌ Done') {
+      await ctx.reply('Please select at least one interest.');
+      await ctx.reply('Choose your interests:', {
+        reply_markup: buildInterestsKeyboard(selected).oneTime(),
+      });
+      continue;
+    }
+
+    if (text === '✔️ Done') {
+      break;
+    }
+
+    if (text === '➕ Add Custom') {
+      await ctx.reply('Type your custom interest (one word/tag):', {
+        reply_markup: new Keyboard().text('Back').resized().oneTime(),
+      });
+      const customResp = await conversation.wait();
+      if (customResp.message?.text && customResp.message.text !== 'Back') {
+        const custom = customResp.message.text.trim().toLowerCase().slice(0, 30);
+        if (custom.length > 0 && ![...selected].some((s) => interestLabelToValue(s) === custom)) {
+          selected.add(custom);
+        }
+      }
+      await ctx.reply(`Selected: ${[...selected].map(interestLabelToValue).join(', ')}`, {
+        reply_markup: buildInterestsKeyboard(selected).oneTime(),
+      });
+      continue;
+    }
+
+    const value = interestLabelToValue(text);
+    const existing = [...selected].find((s) => interestLabelToValue(s) === value);
+    if (existing) {
+      selected.delete(existing);
+    } else {
+      selected.add(text);
+    }
+
+    await ctx.reply(`Selected: ${[...selected].map(interestLabelToValue).join(', ')}`, {
+      reply_markup: buildInterestsKeyboard(selected).oneTime(),
     });
-    return;
   }
+
+  const interests = [...selected].map(interestLabelToValue);
 
   const userId = String(ctx.from?.id);
-
   const result = await conversation.external(() =>
     Effect.runPromise(Effect.either(userService.updateUser(userId, { interests }))),
   );
@@ -223,17 +300,14 @@ export async function editLocation(
   conversation: Conversation<MyContext, MyContext>,
   ctx: MyContext,
 ) {
-  await ctx.reply(
-    "Please share your location or enter your city manually (e.g., 'Seoul, South Korea'):",
-    {
-      reply_markup: new Keyboard()
-        .requestLocation('📍 Share Location')
-        .row()
-        .text('Cancel')
-        .resized()
-        .oneTime(),
-    },
-  );
+  await ctx.reply('📍 Share your location so we can find matches near you:', {
+    reply_markup: new Keyboard()
+      .requestLocation('📍 Share Location')
+      .row()
+      .text('Cancel')
+      .resized()
+      .oneTime(),
+  });
 
   const response = await conversation.wait();
 
@@ -242,40 +316,26 @@ export async function editLocation(
     return;
   }
 
-  const userId = String(ctx.from?.id);
-  let locationData: { latitude?: number; longitude?: number; city?: string; country?: string } = {};
-
-  if (response.message?.location) {
-    // User shared GPS location
-    locationData = {
-      latitude: response.message.location.latitude,
-      longitude: response.message.location.longitude,
-    };
-    // TODO: Reverse geocode to get city/country from API
-  } else if (response.message?.text) {
-    // User entered text location
-    const parts = response.message.text.split(',').map((p) => p.trim());
-    if (parts.length >= 2) {
-      locationData = {
-        city: parts[0],
-        country: parts[1],
-      };
-      // TODO: Geocode to get coordinates from API
-    } else {
-      await ctx.reply('Please use format: City, Country. Cancelled.', {
-        reply_markup: { remove_keyboard: true },
-      });
-      return;
-    }
-  } else {
-    await ctx.reply('Invalid input. Cancelled.', {
+  if (!response.message?.location) {
+    await ctx.reply('Please share your location using the button.', {
       reply_markup: { remove_keyboard: true },
     });
     return;
   }
 
+  const userId = String(ctx.from?.id);
+
   const result = await conversation.external(() =>
-    Effect.runPromise(Effect.either(userService.updateUser(userId, { location: locationData }))),
+    Effect.runPromise(
+      Effect.either(
+        userService.updateUser(userId, {
+          location: {
+            latitude: response.message!.location!.latitude,
+            longitude: response.message!.location!.longitude,
+          },
+        }),
+      ),
+    ),
   );
 
   if (result._tag === 'Left') {
@@ -286,11 +346,5 @@ export async function editLocation(
     return;
   }
 
-  const locationText = locationData.city
-    ? `${locationData.city}, ${locationData.country}`
-    : `📍 ${locationData.latitude?.toFixed(4)}, ${locationData.longitude?.toFixed(4)}`;
-
-  await ctx.reply(`✅ Location updated to ${locationText}!`, {
-    reply_markup: { remove_keyboard: true },
-  });
+  await ctx.reply('✅ Location updated!', { reply_markup: { remove_keyboard: true } });
 }

--- a/services/bot/src/conversations/profile.ts
+++ b/services/bot/src/conversations/profile.ts
@@ -206,7 +206,7 @@ function buildInterestsKeyboard(selected: Set<string>): Keyboard {
 }
 
 function interestLabelToValue(label: string): string {
-  return label.replace(/^[✅➕✔️❌]\s*/, '').toLowerCase();
+  return label.replace(/^(✅|➕|✔️|❌)\s*/, '').toLowerCase();
 }
 
 export async function editInterests(
@@ -330,8 +330,8 @@ export async function editLocation(
       Effect.either(
         userService.updateUser(userId, {
           location: {
-            latitude: response.message!.location!.latitude,
-            longitude: response.message!.location!.longitude,
+            latitude: response.message?.location?.latitude,
+            longitude: response.message?.location?.longitude,
           },
         }),
       ),

--- a/services/bot/src/handlers/match.test.ts
+++ b/services/bot/src/handlers/match.test.ts
@@ -61,7 +61,7 @@ describe('Match Handler', () => {
     it('should display match profile when matches exist', async () => {
       const potentialUser = createMockUser({
         id: 'user2',
-        firstName: 'Jane',
+        displayName: 'Jane',
         age: 25,
         gender: 'female',
         bio: 'Hello!',
@@ -177,7 +177,7 @@ describe('Match Handler', () => {
 
       const otherUser = createMockUser({
         id: 'user2',
-        firstName: 'Jane',
+        displayName: 'Jane',
       });
 
       vi.mocked(matchService.likeMatch).mockReturnValue(

--- a/services/bot/src/handlers/match.ts
+++ b/services/bot/src/handlers/match.ts
@@ -73,7 +73,7 @@ export const matchCommand = (ctx: Context) =>
 
     const message = MATCH_PROFILE_TEMPLATE(
       // Helper function or string literal
-      matchUser.firstName,
+      matchUser.displayName,
       matchUser.age,
       matchUser.gender,
       matchUser.bio || 'No bio',
@@ -173,7 +173,7 @@ export const handleLike = (ctx: Context, matchId: string) =>
       // Fetch other user's details to show their name
       const otherUserRes = yield* _(userService.getUser(otherUserId));
       const otherUser = otherUserRes.user;
-      const otherName = otherUser?.firstName || 'your match';
+      const otherName = otherUser?.displayName || 'your match';
       const template = getRandomStarter();
 
       yield* _(

--- a/services/bot/src/handlers/matches.test.ts
+++ b/services/bot/src/handlers/matches.test.ts
@@ -67,7 +67,7 @@ describe('Matches List Handler', () => {
 
       const otherUser = createMockUser({
         id: 'user2',
-        firstName: 'Jane',
+        displayName: 'Jane',
         age: 25,
       });
 
@@ -151,7 +151,7 @@ describe('Matches List Handler', () => {
 
       const otherUser = createMockUser({
         id: 'user2',
-        firstName: 'Jane',
+        displayName: 'Jane',
         age: 25,
         gender: 'female',
         bio: 'Hello!',

--- a/services/bot/src/handlers/matches.ts
+++ b/services/bot/src/handlers/matches.ts
@@ -56,7 +56,7 @@ export const matchesCommand = (ctx: Context) =>
         const otherUser = userRes.user;
 
         if (otherUser) {
-          const name = otherUser.firstName || 'Unknown';
+          const name = otherUser.displayName || 'Unknown';
           const age = otherUser.age || '?';
           const matchDate = match.matchedAt
             ? new Date(Number(match.matchedAt.seconds) * 1000).toLocaleDateString()
@@ -166,7 +166,7 @@ export const matchesCallbacks = (ctx: Context) =>
         : 'Unknown';
 
       const profileText = `
-👤 *${escapeMarkdown(user.firstName)}*, ${user.age || '?'}
+👤 *${escapeMarkdown(user.displayName)}*, ${user.age || '?'}
 ⚧ ${escapeMarkdown(user.gender || 'Unknown')}
 
 📝 ${escapeMarkdown(user.bio || 'No bio')}

--- a/services/bot/src/handlers/profile.test.ts
+++ b/services/bot/src/handlers/profile.test.ts
@@ -57,7 +57,9 @@ describe('Profile Handler', () => {
 
     await profileCommand(mockContext);
 
-    expect(mockContext.reply).toHaveBeenLastCalledWith(expect.stringContaining('Profile not found'));
+    expect(mockContext.reply).toHaveBeenLastCalledWith(
+      expect.stringContaining('Profile not found'),
+    );
   });
 
   it('should handle errors when fetching profile', async () => {

--- a/services/bot/src/handlers/profile.test.ts
+++ b/services/bot/src/handlers/profile.test.ts
@@ -38,9 +38,9 @@ describe('Profile Handler', () => {
 
     await profileCommand(mockContext);
 
-    expect(userService.getUser).toHaveBeenCalledWith('12345');
-    expect(mockContext.reply).toHaveBeenCalledWith(
-      expect.stringContaining('Name: John Doe'),
+    expect(userService.getUser).toHaveBeenLastCalledWith('12345');
+    expect(mockContext.reply).toHaveBeenLastCalledWith(
+      expect.stringContaining('Name: John'),
       expect.any(Object),
     );
   });
@@ -57,7 +57,7 @@ describe('Profile Handler', () => {
 
     await profileCommand(mockContext);
 
-    expect(mockContext.reply).toHaveBeenCalledWith(expect.stringContaining('Profile not found'));
+    expect(mockContext.reply).toHaveBeenLastCalledWith(expect.stringContaining('Profile not found'));
   });
 
   it('should handle errors when fetching profile', async () => {
@@ -70,7 +70,7 @@ describe('Profile Handler', () => {
 
     await profileCommand(mockContext);
 
-    expect(mockContext.reply).toHaveBeenCalledWith(
+    expect(mockContext.reply).toHaveBeenLastCalledWith(
       expect.stringContaining('Could not load profile'),
     );
   });
@@ -103,7 +103,7 @@ describe('Profile Handler', () => {
 
     await profileCommand(mockContext);
 
-    expect(mockContext.reply).toHaveBeenCalledWith(
+    expect(mockContext.reply).toHaveBeenLastCalledWith(
       expect.stringContaining('Jane'),
       expect.any(Object),
     );

--- a/services/bot/src/handlers/profile.test.ts
+++ b/services/bot/src/handlers/profile.test.ts
@@ -25,7 +25,7 @@ describe('Profile Handler', () => {
     } as unknown as Context;
 
     const mockUser = createMockUser({
-      firstName: 'John',
+      displayName: 'John',
       lastName: 'Doe',
       username: 'johndoe',
       age: 25,
@@ -95,7 +95,7 @@ describe('Profile Handler', () => {
     } as unknown as Context;
 
     const mockUser = createMockUser({
-      firstName: 'Jane',
+      displayName: 'Jane',
       lastName: '',
       bio: '',
       location: undefined,

--- a/services/bot/src/handlers/profile.ts
+++ b/services/bot/src/handlers/profile.ts
@@ -31,7 +31,7 @@ export const profileCommand = (ctx: Context) =>
       const msg = [
         '👤 Profile',
         '',
-        `Name: ${user.firstName || 'Not set'}`,
+        `Name: ${user.displayName || 'Not set'}`,
         `Username: ${user.username ? `@${user.username}` : 'N/A'}`,
         `Age: ${user.age || 'Not set'}`,
         `Gender: ${user.gender || 'Not set'}`,

--- a/services/bot/src/handlers/profile.ts
+++ b/services/bot/src/handlers/profile.ts
@@ -28,18 +28,18 @@ export const profileCommand = (ctx: Context) =>
         return;
       }
 
-      const msg = `
-👤 Profile
-
-Name: ${user.firstName} ${user.lastName || ''}
-Username: ${user.username ? `@${user.username}` : 'N/A'}
-Age: ${user.age || 'Not set'}
-Gender: ${user.gender || 'Not set'}
-Bio: ${user.bio || 'Not set'}
-Location: ${user.location?.city || 'Unknown'}, ${user.location?.country || ''}
-
-Use the buttons below to edit your profile.
-`;
+      const msg = [
+        '👤 Profile',
+        '',
+        `Name: ${user.firstName || 'Not set'}`,
+        `Username: ${user.username ? `@${user.username}` : 'N/A'}`,
+        `Age: ${user.age || 'Not set'}`,
+        `Gender: ${user.gender || 'Not set'}`,
+        `Bio: ${user.bio || 'Not set'}`,
+        `Location: ${user.location?.city || 'Unknown'}, ${user.location?.country || ''}`,
+        '',
+        'Use the buttons below to edit your profile.',
+      ].join('\n');
       yield* Effect.tryPromise(() => ctx.reply(msg, { reply_markup: profileMenu }));
     }),
   );

--- a/services/bot/src/handlers/start.test.ts
+++ b/services/bot/src/handlers/start.test.ts
@@ -37,7 +37,7 @@ describe('Start Handler', () => {
       expect.objectContaining({
         id: '123456',
         username: 'testuser',
-        firstName: 'Test',
+        displayName: 'Test',
         lastName: 'User',
         isActive: true,
       }),
@@ -100,7 +100,7 @@ describe('Start Handler', () => {
     expect(userService.createUser).toHaveBeenCalledWith(
       expect.objectContaining({
         id: '789',
-        firstName: 'NoUsername',
+        displayName: 'NoUsername',
       }),
     );
     expect(mockContext.reply).toHaveBeenCalled();

--- a/services/bot/src/handlers/start.ts
+++ b/services/bot/src/handlers/start.ts
@@ -26,7 +26,7 @@ export const startCommand = (ctx: Context) =>
       const user = new User({
         id: String(ctx.from.id),
         username: ctx.from.username,
-        firstName: ctx.from.first_name,
+        displayName: ctx.from.first_name,
         lastName: ctx.from.last_name,
         isActive: true,
       });

--- a/services/bot/src/services/notificationService.ts
+++ b/services/bot/src/services/notificationService.ts
@@ -175,10 +175,10 @@ Start a conversation now 👋
   enqueueWelcome: (
     userId: string,
     chatId: string,
-    firstName: string,
+    displayName: string,
   ): Effect.Effect<EnqueueNotificationResponse, unknown> => {
     const text = `
-👋 Welcome to MeetMatch, *${firstName}*!
+👋 Welcome to MeetMatch, *${displayName}*!
 
 I'm here to help you find meaningful connections.
 

--- a/services/bot/src/services/userService.test.ts
+++ b/services/bot/src/services/userService.test.ts
@@ -51,7 +51,7 @@ describe('UserService', () => {
   it('should return Effect for createUser', async () => {
     const { userService } = await import('./userService.js');
 
-    const result = userService.createUser({ id: 'test', firstName: 'Test' });
+    const result = userService.createUser({ id: 'test', displayName: 'Test' });
 
     expect(Effect.isEffect(result)).toBe(true);
   });
@@ -59,7 +59,7 @@ describe('UserService', () => {
   it('should return Effect for updateUser', async () => {
     const { userService } = await import('./userService.js');
 
-    const result = userService.updateUser('test-user-id', { firstName: 'Updated' });
+    const result = userService.updateUser('test-user-id', { displayName: 'Updated' });
 
     expect(Effect.isEffect(result)).toBe(true);
   });

--- a/services/bot/src/test/fixtures.ts
+++ b/services/bot/src/test/fixtures.ts
@@ -39,7 +39,7 @@ export const createMockUser = (overrides: Record<string, unknown> = {}): User =>
   ({
     id: 'user123',
     username: 'testuser',
-    firstName: 'Test',
+    displayName: 'Test',
     lastName: 'User',
     bio: 'Test bio',
     age: 25,

--- a/services/cf-bot/migrations/0001_init_schema.sql
+++ b/services/cf-bot/migrations/0001_init_schema.sql
@@ -1,0 +1,86 @@
+CREATE TABLE IF NOT EXISTS users (
+    id TEXT PRIMARY KEY,
+    username TEXT,
+    display_name TEXT NOT NULL,
+    last_name TEXT,
+    bio TEXT,
+    age INTEGER,
+    gender TEXT,
+    interests TEXT DEFAULT '[]',
+    photos TEXT DEFAULT '[]',
+    location TEXT DEFAULT '{}',
+    preferences TEXT DEFAULT '{}',
+    is_active INTEGER DEFAULT 1,
+    is_sleeping INTEGER DEFAULT 0,
+    is_profile_complete INTEGER DEFAULT 0,
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now')),
+    last_active TEXT DEFAULT (datetime('now')),
+    last_reminded_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_users_username ON users(username);
+CREATE INDEX IF NOT EXISTS idx_users_age ON users(age);
+CREATE INDEX IF NOT EXISTS idx_users_gender ON users(gender);
+
+CREATE TABLE IF NOT EXISTS matches (
+    id TEXT PRIMARY KEY,
+    user1_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    user2_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'matched', 'rejected')),
+    score TEXT DEFAULT '{}',
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now')),
+    matched_at TEXT,
+    user1_action TEXT DEFAULT 'none',
+    user2_action TEXT DEFAULT 'none'
+);
+
+CREATE INDEX IF NOT EXISTS idx_matches_user1 ON matches(user1_id);
+CREATE INDEX IF NOT EXISTS idx_matches_user2 ON matches(user2_id);
+CREATE INDEX IF NOT EXISTS idx_matches_status ON matches(status);
+
+CREATE TABLE IF NOT EXISTS notifications (
+    id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    type TEXT NOT NULL CHECK (type IN ('mutual_match', 'new_like', 'match_reminder', 'profile_incomplete', 'welcome', 'system')),
+    channel TEXT NOT NULL DEFAULT 'telegram' CHECK (channel IN ('telegram', 'email', 'push', 'sms')),
+    payload TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'processing', 'delivered', 'failed', 'dlq', 'cancelled')),
+    priority INTEGER NOT NULL DEFAULT 0 CHECK (priority >= 0 AND priority <= 10),
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    max_attempts INTEGER NOT NULL DEFAULT 5,
+    next_retry_at TEXT,
+    last_error TEXT,
+    last_error_code TEXT,
+    related_match_id TEXT REFERENCES matches(id) ON DELETE SET NULL,
+    related_user_id TEXT REFERENCES users(id) ON DELETE SET NULL,
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now')),
+    delivered_at TEXT,
+    dlq_at TEXT,
+    idempotency_key TEXT UNIQUE,
+    expires_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_notifications_user_id ON notifications(user_id);
+CREATE INDEX IF NOT EXISTS idx_notifications_status ON notifications(status);
+CREATE INDEX IF NOT EXISTS idx_notifications_type ON notifications(type);
+
+CREATE TABLE IF NOT EXISTS notification_attempts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    notification_id TEXT NOT NULL REFERENCES notifications(id) ON DELETE CASCADE,
+    attempted_at TEXT DEFAULT (datetime('now')),
+    status TEXT NOT NULL CHECK (status IN ('success', 'failed', 'retry')),
+    error_message TEXT,
+    error_code TEXT,
+    duration_ms INTEGER,
+    metadata TEXT DEFAULT '{}'
+);
+
+CREATE INDEX IF NOT EXISTS idx_notification_attempts_notification ON notification_attempts(notification_id);
+
+CREATE TABLE IF NOT EXISTS schema_migrations (
+    version TEXT PRIMARY KEY,
+    applied_at TEXT DEFAULT (datetime('now'))
+);

--- a/services/cf-bot/src/handlers/match.ts
+++ b/services/cf-bot/src/handlers/match.ts
@@ -24,7 +24,7 @@ function buildMatchKeyboard(targetUserId: string) {
 }
 
 function formatProfile(user: Record<string, unknown>, index: number): string {
-  const name = (user.firstName ?? user.first_name ?? "Unknown") as string;
+  const name = (user.displayName ?? user.first_name ?? "Unknown") as string;
   const age = user.age ?? "?";
   const bio = user.bio ? `\n📝 ${user.bio}` : "";
   const interests = user.interests

--- a/services/cf-bot/src/handlers/matches.ts
+++ b/services/cf-bot/src/handlers/matches.ts
@@ -18,7 +18,7 @@ async function fetchMatches(env: Env, userId: string) {
 }
 
 function formatMatch(match: Record<string, unknown>): string {
-  const name = (match.firstName ?? match.first_name ?? "Unknown") as string;
+  const name = (match.displayName ?? match.first_name ?? "Unknown") as string;
   const age = match.age ?? "?";
   const bio = match.bio ? `\n📝 ${match.bio}` : "";
   return `💕 ${name}, ${age}${bio}\nMatched at: ${match.matched_at ?? "recently"}`;

--- a/services/cf-bot/src/handlers/profile.ts
+++ b/services/cf-bot/src/handlers/profile.ts
@@ -1,10 +1,51 @@
 import type { MyContext } from '../types.js';
 import { getProfileMenu } from '../menus/profile.js';
 import type { Env } from '../index.js';
+import { ApiServiceClient } from '../services/api-client.js';
 
 export const profileCommand = async (ctx: MyContext, env: Env): Promise<void> => {
-  await ctx.reply('👤 *Your Profile*\n\nSelect a field to edit:', {
-    parse_mode: 'Markdown',
+  if (!ctx.from) {
+    await ctx.reply('Could not load profile. Please try /start first.');
+    return;
+  }
+
+  let user: Record<string, unknown> | undefined;
+  try {
+    const client = new ApiServiceClient(env.API_SERVICE);
+    const response = await client.getUser({ userId: String(ctx.from.id) });
+    user = response.user as Record<string, unknown> | undefined;
+  } catch {
+    await ctx.reply('Could not load profile. Please try /start first.');
+    return;
+  }
+
+  if (!user) {
+    await ctx.reply('Profile not found. Please use /start first.');
+    return;
+  }
+
+  const name = (user.displayName as string) || 'Not set';
+  const username = (user.username as string) ? `@${user.username}` : 'N/A';
+  const age = user.age || 'Not set';
+  const gender = user.gender || 'Not set';
+  const bio = user.bio || 'Not set';
+  const loc = (user as Record<string, any>).location;
+  const locationText = loc?.city ? `${loc.city}, ${loc.country}` : loc?.latitude ? `📍 Shared` : 'Not set';
+
+  const msg = [
+    '👤 Profile',
+    '',
+    `Name: ${name}`,
+    `Username: ${username}`,
+    `Age: ${age}`,
+    `Gender: ${gender}`,
+    `Bio: ${bio}`,
+    `Location: ${locationText}`,
+    '',
+    'Select a field to edit:',
+  ].join('\n');
+
+  await ctx.reply(msg, {
     reply_markup: getProfileMenu(env),
   });
 };

--- a/services/cf-bot/src/handlers/start.ts
+++ b/services/cf-bot/src/handlers/start.ts
@@ -1,4 +1,6 @@
 import type { MyContext } from '../types.js';
+import type { Env } from '../index.js';
+import { ApiServiceClient } from '../services/api-client.js';
 
 const WELCOME_MESSAGE = `
 👋 Welcome to MeetMatch!
@@ -13,6 +15,23 @@ To get started:
 Need help? Just type /help anytime.
 `;
 
-export const startCommand = async (ctx: MyContext): Promise<void> => {
+export const startCommand = async (ctx: MyContext, env: Env): Promise<void> => {
+  if (!ctx.from) {
+    await ctx.reply(WELCOME_MESSAGE);
+    return;
+  }
+
+  try {
+    const client = new ApiServiceClient(env.API_SERVICE);
+    await client.createUser({
+      user: {
+        id: String(ctx.from.id),
+        username: ctx.from.username ?? undefined,
+        displayName: ctx.from.first_name,
+        isActive: true,
+      },
+    });
+  } catch {}
+
   await ctx.reply(WELCOME_MESSAGE);
 };

--- a/services/cf-bot/src/index.ts
+++ b/services/cf-bot/src/index.ts
@@ -40,7 +40,7 @@ function createBot(env: Env): Bot<MyContext> {
 
   bot.use(activityTrackerMiddleware(env));
 
-  bot.command('start', startCommand);
+  bot.command('start', (ctx) => startCommand(ctx, env));
   bot.command('help', helpCommand);
   bot.command('about', aboutCommand);
   bot.command('profile', (ctx) => profileCommand(ctx, env));

--- a/services/cf-bot/src/lib/conversations.ts
+++ b/services/cf-bot/src/lib/conversations.ts
@@ -165,9 +165,21 @@ async function handleInterestsConversation(ctx: MyContext, env: Env, state: Conv
 }
 
 async function handleLocationConversation(ctx: MyContext, env: Env, state: ConversationState, text: string): Promise<boolean> {
+  if (ctx.message?.location) {
+    const { latitude, longitude } = ctx.message.location;
+    const success = await updateUser(env, state.userId, { location: { latitude, longitude } });
+    await clearConversationState(env.KV, state.userId);
+    if (success) {
+      await ctx.reply('📍 Location updated from GPS!', { reply_markup: { remove_keyboard: true } });
+    } else {
+      await ctx.reply('Failed to update location. Please try again later.', { reply_markup: { remove_keyboard: true } });
+    }
+    return true;
+  }
+
   const parts = text.split(',').map((s) => s.trim());
   if (parts.length < 2) {
-    await ctx.reply('Please enter city and country separated by a comma (e.g., "Jakarta, Indonesia"). Try again or type Cancel.');
+    await ctx.reply('Please enter city and country separated by a comma (e.g., "Jakarta, Indonesia"), or share your location. Try again or type Cancel.');
     return true;
   }
   const [city, country] = parts;

--- a/services/cf-bot/src/lib/conversations.ts
+++ b/services/cf-bot/src/lib/conversations.ts
@@ -117,7 +117,7 @@ async function handleNameConversation(ctx: MyContext, env: Env, state: Conversat
     await ctx.reply('Name must be 1-50 characters. Try again or type Cancel.');
     return true;
   }
-  const success = await updateUser(env, state.userId, { firstName: name });
+  const success = await updateUser(env, state.userId, { displayName: name });
   await clearConversationState(env.KV, state.userId);
   if (success) {
     await ctx.reply(`Name updated to ${name}!`, { reply_markup: { remove_keyboard: true } });

--- a/services/cf-bot/src/menus/profile.ts
+++ b/services/cf-bot/src/menus/profile.ts
@@ -32,7 +32,7 @@ export async function handleProfileCallback(ctx: MyContext, env: Env, data: stri
       return true;
     case 'profile:name':
       await startConversation(env.KV, userId, 'name');
-      await ctx.reply('Please enter your first name (1-50 characters). Type Cancel to abort.');
+      await ctx.reply('What name should other users see? (1-50 characters). Type Cancel to abort.');
       return true;
     case 'profile:gender':
       await startConversation(env.KV, userId, 'gender');
@@ -44,7 +44,7 @@ export async function handleProfileCallback(ctx: MyContext, env: Env, data: stri
       return true;
     case 'profile:location':
       await startConversation(env.KV, userId, 'location');
-      await ctx.reply('Enter your city and country, separated by a comma. Type Cancel to abort.');
+      await ctx.reply('Enter your city and country (e.g., "Jakarta, Indonesia"), or share your GPS location. Type Cancel to abort.');
       return true;
     case 'profile:close':
       await ctx.deleteMessage();


### PR DESCRIPTION
## Summary

Fixes registration/profile not working on dev by addressing two root causes:

### 1. ConnectRPC Protocol Mismatch (Critical)
The TypeScript bot used `@connectrpc/connect` to call the API, but the Go API only had standard gRPC (HTTP/2) handlers on port 50051. The HTTP server on port 8080 (where the bot was connecting) only had `/` and `/health` endpoints. 

**Fix**: Added `connectrpc/go` protobuf plugin, generated ConnectRPC Go stubs, created adapter layer for existing services, and registered ConnectRPC handlers on the HTTP server (port 8080). This enables Connect/gRPC-Web over HTTP/1.1.

### 2. SQLite Time Scanning Bug
`modernc.org/sqlite` stores `CURRENT_TIMESTAMP` as TEXT, but the Go code tried scanning it directly into `time.Time`, causing: `unsupported Scan, storing driver.Value type string into type *time.Time`.

**Fix**: Added `SQLiteTime` custom type implementing `sql.Scanner`/`driver.Valuer` to handle TEXT ↔ time.Time conversion for User and Match models.

### Bonus: Database Migration Runner
Migrations existed as `.up.sql` files but were never executed at startup. Added a migration runner that applies them on first run, tracking applied versions in a `schema_migrations` table.

## Changes

| File | Change |
|------|--------|
| `buf.gen.yaml` | Added `connectrpc/go` plugin |
| `services/api/internal/httpserver/connect.go` | New: ConnectRPC adapters for UserService, MatchService, HealthService |
| `services/api/internal/httpserver/server.go` | Replaced Fiber with `net/http` ServeMux combining ConnectRPC + REST |
| `services/api/internal/models/user.go` | Added `SQLiteTime` type, updated User struct |
| `services/api/internal/models/match.go` | Updated Match struct to use `SQLiteTime` |
| `services/api/internal/migrate/migrate.go` | New: Database migration runner |
| `services/api/cmd/api/main.go` | Wire migrations, ConnectRPC handler, remove Fiber |
| `services/api/internal/services/user.go` | Updated to use `SQLiteTime` |
| `services/api/internal/services/match.go` | Updated to use `SQLiteTime` |

## Testing

- ✅ All 55 Go API tests pass
- ✅ All 170 TypeScript bot tests pass
- ✅ Local integration test: CreateUser → GetUser → UpdateUser → GetUser all work via ConnectRPC
- ✅ Duplicate user detection works (AlreadyExists)
- ✅ Health endpoint works

```
curl -X POST http://localhost:8080/meetsmatch.v1.UserService/CreateUser \
  -H "Content-Type: application/json" \
  -H "Connect-Protocol-Version: 1" \
  -d '{"user":{"id":"test123","firstName":"Test","isActive":true}}'
# → Returns created user with all fields
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API now exposes ConnectRPC handlers; services run DB migrations automatically at startup.
  * Bot: interactive interests selector and location-by-button flow; profile fetch shows live data.

* **Refactor**
  * Replaced previous HTTP server with net/http-based handler and updated server wiring.
  * Introduced SQLite-aware time handling type across models and service mappings.

* **Contracts / Migrations**
  * Renamed user name field to displayName/display_name in contracts and added DB migration.

* **Tests / CI**
  * Updated tests and added Docker smoke-test CI jobs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/irfndi/meets-match/pull/122)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->