### PR TITLE
fix(cf): /start not creating user profile

### DIFF
--- a/services/cf-api/src/models/__tests__/user.test.ts
+++ b/services/cf-api/src/models/__tests__/user.test.ts
@@ -46,7 +46,7 @@ describe("UserRepository", () => {
     const { Effect } = await import("effect");
     const user = await Effect.runPromise(repo.getById({ userId: "1" }));
     expect(user.id).toBe("1");
-    expect(user.firstName).toBe("Test");
+    expect(user.displayName).toBe("Test");
   });
 
   it("should throw NotFoundError for missing user", async () => {
@@ -59,10 +59,10 @@ describe("UserRepository", () => {
   it("should create a new user", async () => {
     const { Effect } = await import("effect");
     const result = await Effect.runPromise(repo.create({
-      user: { id: "1", firstName: "Alice", age: 30, gender: "female" as any }
+      user: { id: "1", displayName: "Alice", age: 30, gender: "female" as any }
     }));
     expect(result.id).toBe("1");
-    expect(result.firstName).toBe("Alice");
+    expect(result.displayName).toBe("Alice");
   });
 
   it("should update existing user with upsert", async () => {

--- a/services/cf-api/src/models/match.ts
+++ b/services/cf-api/src/models/match.ts
@@ -223,7 +223,7 @@ export class MatchRepository {
     return {
       id: String(row.id),
       username: row.username ? String(row.username) : undefined,
-      firstName: row.first_name ? String(row.first_name) : undefined,
+      displayName: row.first_name ? String(row.first_name) : undefined,
       lastName: row.last_name ? String(row.last_name) : undefined,
       bio: row.bio ? String(row.bio) : undefined,
       age: row.age ? Number(row.age) : undefined,

--- a/services/cf-api/src/models/user.ts
+++ b/services/cf-api/src/models/user.ts
@@ -44,7 +44,7 @@ export class UserRepository {
           .bind(
             user.id,
             user.username ?? null,
-            user.displayName ?? null,
+            user.displayName ?? "User",
             user.lastName ?? null,
             user.bio ?? null,
             user.age ?? null,

--- a/services/cf-api/src/models/user.ts
+++ b/services/cf-api/src/models/user.ts
@@ -44,7 +44,7 @@ export class UserRepository {
           .bind(
             user.id,
             user.username ?? null,
-            user.firstName ?? null,
+            user.displayName ?? null,
             user.lastName ?? null,
             user.bio ?? null,
             user.age ?? null,
@@ -75,14 +75,14 @@ export class UserRepository {
         if (!existing) {
           await this.db.prepare(
             `INSERT INTO users (id, first_name) VALUES (?, ?)`
-          ).bind(req.userId, user.firstName ?? "User").run();
+          ).bind(req.userId, user.displayName ?? "User").run();
         }
 
         const fields: string[] = [];
         const values: unknown[] = [];
 
         if (user.username !== undefined) { fields.push("username = ?"); values.push(user.username); }
-        if (user.firstName !== undefined) { fields.push("first_name = ?"); values.push(user.firstName); }
+        if (user.displayName !== undefined) { fields.push("first_name = ?"); values.push(user.displayName); }
         if (user.lastName !== undefined) { fields.push("last_name = ?"); values.push(user.lastName); }
         if (user.bio !== undefined) { fields.push("bio = ?"); values.push(user.bio); }
         if (user.age !== undefined) { fields.push("age = ?"); values.push(user.age); }
@@ -155,7 +155,7 @@ export class UserRepository {
     return {
       id: String(row.id),
       username: row.username ? String(row.username) : undefined,
-      firstName: row.first_name ? String(row.first_name) : undefined,
+      displayName: row.first_name ? String(row.first_name) : undefined,
       lastName: row.last_name ? String(row.last_name) : undefined,
       bio: row.bio ? String(row.bio) : undefined,
       age: row.age ? Number(row.age) : undefined,

--- a/services/cf-api/src/tests/integration.test.ts
+++ b/services/cf-api/src/tests/integration.test.ts
@@ -109,7 +109,7 @@ describe('API Integration', () => {
       body: JSON.stringify({
         user: {
           id: '123',
-          firstName: 'Test',
+          displayName: 'Test',
           age: 25,
           gender: 'male',
           isActive: true,

--- a/services/cf-bot/src/__tests__/handlers.test.ts
+++ b/services/cf-bot/src/__tests__/handlers.test.ts
@@ -22,7 +22,8 @@ describe("Bot Handlers", () => {
   describe("startCommand", () => {
     it("should send welcome message", async () => {
       const ctx = mockCtx();
-      await startCommand(ctx);
+      const env = { API_SERVICE: { fetch: vi.fn().mockResolvedValue(new Response(JSON.stringify({ user: { id: "123" } }), { status: 201 })) } } as any;
+      await startCommand(ctx, env);
       expect(ctx.reply).toHaveBeenCalled();
       const message = (ctx.reply as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
       expect(message).toContain("Welcome");

--- a/services/cf-bot/src/handlers/start.ts
+++ b/services/cf-bot/src/handlers/start.ts
@@ -31,7 +31,9 @@ export const startCommand = async (ctx: MyContext, env: Env): Promise<void> => {
         isActive: true,
       },
     });
-  } catch {}
+  } catch (error) {
+    console.error('Failed to create user on /start:', error);
+  }
 
   await ctx.reply(WELCOME_MESSAGE);
 };

--- a/services/cf-bot/src/handlers/start.ts
+++ b/services/cf-bot/src/handlers/start.ts
@@ -33,6 +33,8 @@ export const startCommand = async (ctx: MyContext, env: Env): Promise<void> => {
     });
   } catch (error) {
     console.error('Failed to create user on /start:', error);
+    await ctx.reply('❌ Sorry, there was an error setting up your profile. Please try again later.');
+    return;
   }
 
   await ctx.reply(WELCOME_MESSAGE);


### PR DESCRIPTION
## Problem

`/start` in cf-bot was failing silently to create users, so `/profile` returned "Profile not found. Please use /start first."

## Root Cause

1. **Field name mismatch**: `cf-bot` sends `displayName` per the shared contract, but `cf-api` user model was reading `user.firstName`. This caused a D1 `NOT NULL constraint failed: first_name` error on every `/start`.
2. **Silent failure**: `cf-bot` had an empty `catch {}` that swallowed the API error, so users saw the welcome message even though no profile was created.

## Changes

- **cf-api**: Map `displayName` <-> DB column `first_name` in `UserRepository` and `MatchRepository.rowToUser`.
- **cf-bot**: Replace empty `catch {}` with `console.error` logging so failures are visible.
- **tests**: Update assertions and payloads to use `displayName`.

All cf-api and cf-bot tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added error logging for user creation failures in the bot's `/start` flow.

* **Refactor**
  * Updated user profile data model to use `displayName` field instead of `firstName`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/irfndi/meets-match/pull/123)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->