### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through a stack trace

### DIFF
--- a/services/cf-bot/src/index.ts
+++ b/services/cf-bot/src/index.ts
@@ -600,11 +600,14 @@ export default {
       } catch (error) {
         const errorMessage =
           error instanceof Error ? error.message : String(error);
-        console.error("Send notification error:", errorMessage);
-        return new Response(JSON.stringify({ error: errorMessage }), {
-          status: 500,
-          headers: { "Content-Type": "application/json" },
-        });
+        console.error("Send notification error:", error);
+        return new Response(
+          JSON.stringify({ error: "Internal Server Error" }),
+          {
+            status: 500,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
       }
     }
 

--- a/services/cf-bot/src/index.ts
+++ b/services/cf-bot/src/index.ts
@@ -598,8 +598,6 @@ export default {
           headers: { "Content-Type": "application/json" },
         });
       } catch (error) {
-        const errorMessage =
-          error instanceof Error ? error.message : String(error);
         console.error("Send notification error:", error);
         return new Response(
           JSON.stringify({ error: "Internal Server Error" }),


### PR DESCRIPTION
Potential fix for [https://github.com/irfndi/meets-match/security/code-scanning/2](https://github.com/irfndi/meets-match/security/code-scanning/2)

The best fix is to keep detailed error diagnostics in server logs and return a generic error message to the caller.

In `services/cf-bot/src/index.ts`, within the `/send-notification` `catch` block (around lines 600–607), replace the client response payload from `{ error: errorMessage }` to a constant generic message like `{ error: "Internal Server Error" }`. Preserve server-side logging (ideally logging the raw `error` object) so debugging remains possible without exposing internals over HTTP. This change does not alter endpoint behavior (still returns HTTP 500 JSON), only sanitizes exposed content.

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
