### PR TITLE
fix(bot): start profile onboarding after language selection

### DIFF
--- a/services/cf-bot/src/__tests__/conversations.test.ts
+++ b/services/cf-bot/src/__tests__/conversations.test.ts
@@ -5,8 +5,10 @@ import {
   clearConversationState,
   startConversation,
   handleConversationMessage,
+  continueOnboarding,
 } from "../lib/conversations.js";
 import type { MyContext } from "../types.js";
+import type { Language } from "../lib/i18n.js";
 
 function mockKV() {
   const store = new Map<string, string>();
@@ -178,4 +180,458 @@ describe("Conversation Message Handling", () => {
     const result = await handleConversationMessage(ctx, mockEnv(kv));
     expect(result).toBe(true);
   });
+});
+
+// ─────────────────────────────────────────────────────────────
+// Regression tests: continueOnboarding explicit step sequence
+// ─────────────────────────────────────────────────────────────
+
+describe("continueOnboarding — explicit step sequence regression", () => {
+  let kv: ReturnType<typeof mockKV>;
+
+  beforeEach(() => {
+    kv = mockKV();
+    vi.resetModules();
+  });
+
+  function createEnvWithUser(user: Record<string, unknown>) {
+    return {
+      DB: {} as D1Database,
+      KV: kv as unknown as KVNamespace,
+      API_SERVICE: {
+        fetch: vi.fn().mockImplementation((req: Request) => {
+          const url = String(req.url);
+          if (url.includes("/users/123")) {
+            return Promise.resolve(
+              new Response(JSON.stringify({ user }), { status: 200 }),
+            );
+          }
+          return Promise.resolve(
+            new Response(JSON.stringify({}), { status: 404 }),
+          );
+        }),
+      } as unknown as Fetcher,
+      BOT_TOKEN: "test-token",
+    };
+  }
+
+  function mockCtxLang(lang: Language): MyContext {
+    return {
+      reply: vi.fn().mockResolvedValue(undefined),
+      from: {
+        id: 123,
+        first_name: "TestUser",
+        is_bot: false,
+        language_code: lang,
+      },
+      message: undefined,
+    } as unknown as MyContext;
+  }
+
+  // ── Step 1: Name shows once ──
+  it.each<Language>(["en", "id"])(
+    "[%s] starts with name even when displayName is pre-filled",
+    async (lang) => {
+      const env = createEnvWithUser({
+        id: "123",
+        displayName: "TestUser",
+        language: lang,
+      });
+      const ctx = mockCtxLang(lang);
+      const result = await continueOnboarding(ctx, env, "123", lang);
+
+      expect(result).toBe(true);
+      const state = await getConversationState(
+        kv as unknown as KVNamespace,
+        "123",
+      );
+      expect(state!.field).toBe("name");
+
+      // Should have "Use my Telegram name" button
+      const replyCall = (ctx.reply as ReturnType<typeof vi.fn>).mock.calls[0];
+      const keyboard = replyCall[1]?.reply_markup?.keyboard;
+      expect(keyboard).toBeDefined();
+      const buttonTexts = keyboard.flatMap((row: Array<{ text: string }>) =>
+        row.map((b) => b.text),
+      );
+      expect(buttonTexts.length).toBeGreaterThanOrEqual(1);
+    },
+  );
+
+  // ── Step 1b: Name skips if already seen ──
+  it.each<Language>(["en", "id"])(
+    "[%s] skips name when already seen in this session",
+    async (lang) => {
+      await kv.put(`onboarding:seen:123`, JSON.stringify(["name"]));
+      const env = createEnvWithUser({
+        id: "123",
+        displayName: "TestUser",
+        language: lang,
+      });
+      const ctx = mockCtxLang(lang);
+      const result = await continueOnboarding(ctx, env, "123", lang);
+
+      expect(result).toBe(true);
+      const state = await getConversationState(
+        kv as unknown as KVNamespace,
+        "123",
+      );
+      expect(state!.field).toBe("birthdate");
+    },
+  );
+
+  // ── Step 2: Birthdate skips if present ──
+  it.each<Language>(["en", "id"])(
+    "[%s] skips birthdate when already present",
+    async (lang) => {
+      await kv.put(`onboarding:seen:123`, JSON.stringify(["name"]));
+      const env = createEnvWithUser({
+        id: "123",
+        displayName: "TestUser",
+        birthDate: "1995-03-15",
+        language: lang,
+      });
+      const ctx = mockCtxLang(lang);
+      const result = await continueOnboarding(ctx, env, "123", lang);
+
+      expect(result).toBe(true);
+      const state = await getConversationState(
+        kv as unknown as KVNamespace,
+        "123",
+      );
+      expect(state!.field).toBe("gender");
+    },
+  );
+
+  // ── Step 3: Gender skips if present ──
+  it.each<Language>(["en", "id"])(
+    "[%s] skips gender when already present",
+    async (lang) => {
+      await kv.put(`onboarding:seen:123`, JSON.stringify(["name"]));
+      const env = createEnvWithUser({
+        id: "123",
+        displayName: "TestUser",
+        birthDate: "1995-03-15",
+        gender: "male",
+        language: lang,
+      });
+      const ctx = mockCtxLang(lang);
+      const result = await continueOnboarding(ctx, env, "123", lang);
+
+      expect(result).toBe(true);
+      const state = await getConversationState(
+        kv as unknown as KVNamespace,
+        "123",
+      );
+      expect(state!.field).toBe("bio");
+    },
+  );
+
+  // ── Step 4: Bio skips if present ──
+  it.each<Language>(["en", "id"])(
+    "[%s] skips bio when already present",
+    async (lang) => {
+      await kv.put(`onboarding:seen:123`, JSON.stringify(["name"]));
+      const env = createEnvWithUser({
+        id: "123",
+        displayName: "TestUser",
+        birthDate: "1995-03-15",
+        gender: "male",
+        bio: "Hello world",
+        language: lang,
+      });
+      const ctx = mockCtxLang(lang);
+      const result = await continueOnboarding(ctx, env, "123", lang);
+
+      expect(result).toBe(true);
+      const state = await getConversationState(
+        kv as unknown as KVNamespace,
+        "123",
+      );
+      expect(state!.field).toBe("location");
+    },
+  );
+
+  // ── Step 5: Location skips if present ──
+  it.each<Language>(["en", "id"])(
+    "[%s] skips location when already present",
+    async (lang) => {
+      await kv.put(`onboarding:seen:123`, JSON.stringify(["name"]));
+      const env = createEnvWithUser({
+        id: "123",
+        displayName: "TestUser",
+        birthDate: "1995-03-15",
+        gender: "male",
+        bio: "Hello world",
+        location: { city: "Jakarta", country: "Indonesia" },
+        language: lang,
+      });
+      const ctx = mockCtxLang(lang);
+      const result = await continueOnboarding(ctx, env, "123", lang);
+
+      expect(result).toBe(true);
+      const state = await getConversationState(
+        kv as unknown as KVNamespace,
+        "123",
+      );
+      expect(state!.field).toBe("media");
+    },
+  );
+
+  // ── Step 6: Media skips if present ──
+  it.each<Language>(["en", "id"])(
+    "[%s] skips media when already present",
+    async (lang) => {
+      await kv.put(`onboarding:seen:123`, JSON.stringify(["name"]));
+      const env = createEnvWithUser({
+        id: "123",
+        displayName: "TestUser",
+        birthDate: "1995-03-15",
+        gender: "male",
+        bio: "Hello world",
+        location: { city: "Jakarta", country: "Indonesia" },
+        mediaUrls: [
+          { url: "test.jpg", type: "image", uploadedAt: "2024-01-01" },
+        ],
+        language: lang,
+      });
+      const ctx = mockCtxLang(lang);
+      const result = await continueOnboarding(ctx, env, "123", lang);
+
+      expect(result).toBe(true);
+      const state = await getConversationState(
+        kv as unknown as KVNamespace,
+        "123",
+      );
+      // Should skip to interests (interests showOnce but not yet seen)
+      expect(state!.field).toBe("interests");
+    },
+  );
+
+  // ── Step 7: Interests shows once ──
+  it.each<Language>(["en", "id"])(
+    "[%s] shows interests even when already filled (showOnce, not yet seen)",
+    async (lang) => {
+      await kv.put(`onboarding:seen:123`, JSON.stringify(["name"]));
+      const env = createEnvWithUser({
+        id: "123",
+        displayName: "TestUser",
+        birthDate: "1995-03-15",
+        gender: "male",
+        bio: "Hello world",
+        location: { city: "Jakarta", country: "Indonesia" },
+        mediaUrls: [
+          { url: "test.jpg", type: "image", uploadedAt: "2024-01-01" },
+        ],
+        interests: ["Hiking", "Coding"],
+        language: lang,
+      });
+      const ctx = mockCtxLang(lang);
+      const result = await continueOnboarding(ctx, env, "123", lang);
+
+      expect(result).toBe(true);
+      const state = await getConversationState(
+        kv as unknown as KVNamespace,
+        "123",
+      );
+      expect(state!.field).toBe("interests");
+
+      // Should have Skip button
+      const replyCall = (ctx.reply as ReturnType<typeof vi.fn>).mock.calls[0];
+      const keyboard = replyCall[1]?.reply_markup?.keyboard;
+      const buttonTexts = keyboard.flatMap((row: Array<{ text: string }>) =>
+        row.map((b) => b.text),
+      );
+      expect(buttonTexts.length).toBeGreaterThanOrEqual(1);
+    },
+  );
+
+  // ── Step 7b: Interests skips if already seen ──
+  it.each<Language>(["en", "id"])(
+    "[%s] skips interests when already seen",
+    async (lang) => {
+      await kv.put(
+        `onboarding:seen:123`,
+        JSON.stringify(["name", "interests"]),
+      );
+      await kv.put(`onboarding:interests-skipped:123`, "true");
+      const env = createEnvWithUser({
+        id: "123",
+        displayName: "TestUser",
+        birthDate: "1995-03-15",
+        gender: "male",
+        bio: "Hello world",
+        location: { city: "Jakarta", country: "Indonesia" },
+        mediaUrls: [
+          { url: "test.jpg", type: "image", uploadedAt: "2024-01-01" },
+        ],
+        interests: ["Hiking", "Coding"],
+        language: lang,
+      });
+      const ctx = mockCtxLang(lang);
+      const result = await continueOnboarding(ctx, env, "123", lang);
+
+      expect(result).toBe(true);
+      const state = await getConversationState(
+        kv as unknown as KVNamespace,
+        "123",
+      );
+      expect(state!.field).toBe("phone");
+    },
+  );
+
+  // ── Step 8: Phone appears if not verified ──
+  it.each<Language>(["en", "id"])(
+    "[%s] shows phone verification after interests when phone missing",
+    async (lang) => {
+      await kv.put(
+        `onboarding:seen:123`,
+        JSON.stringify(["name", "interests"]),
+      );
+      await kv.put(`onboarding:interests-skipped:123`, "true");
+      const env = createEnvWithUser({
+        id: "123",
+        displayName: "TestUser",
+        birthDate: "1995-03-15",
+        gender: "male",
+        bio: "Hello world",
+        location: { city: "Jakarta", country: "Indonesia" },
+        mediaUrls: [
+          { url: "test.jpg", type: "image", uploadedAt: "2024-01-01" },
+        ],
+        interests: ["Hiking"],
+        language: lang,
+      });
+      const ctx = mockCtxLang(lang);
+
+      const result = await continueOnboarding(ctx, env, "123", lang);
+
+      expect(result).toBe(true);
+      const state = await getConversationState(
+        kv as unknown as KVNamespace,
+        "123",
+      );
+      expect(state!.field).toBe("phone");
+
+      // Should have contact-sharing button
+      const replyCall = (ctx.reply as ReturnType<typeof vi.fn>).mock.calls[0];
+      const keyboard = replyCall[1]?.reply_markup?.keyboard;
+      expect(keyboard).toBeDefined();
+      expect(keyboard[0][0].request_contact).toBe(true);
+    },
+  );
+
+  // ── Complete: all done ──
+  it.each<Language>(["en", "id"])(
+    "[%s] returns false when all steps complete including phone",
+    async (lang) => {
+      await kv.put(
+        `onboarding:seen:123`,
+        JSON.stringify(["name", "interests"]),
+      );
+      const env = createEnvWithUser({
+        id: "123",
+        displayName: "TestUser",
+        birthDate: "1995-03-15",
+        gender: "male",
+        bio: "Hello world",
+        location: { city: "Jakarta", country: "Indonesia" },
+        mediaUrls: [
+          { url: "test.jpg", type: "image", uploadedAt: "2024-01-01" },
+        ],
+        interests: ["Hiking"],
+        phoneNumber: "+1234567890",
+        language: lang,
+      });
+      const ctx = mockCtxLang(lang);
+      const result = await continueOnboarding(ctx, env, "123", lang);
+
+      expect(result).toBe(false);
+      expect(ctx.reply).not.toHaveBeenCalled();
+      // Should clean up onboarding progress
+      const seenRaw = await kv.get(`onboarding:seen:123`);
+      expect(seenRaw).toBeNull();
+    },
+  );
+
+  // ── Full flow simulation: empty profile ──
+  it.each<Language>(["en", "id"])(
+    "[%s] full flow: empty profile → name → birthdate → gender → bio → location → media → interests → phone",
+    async (lang) => {
+      const profile: Record<string, unknown> = {
+        id: "123",
+        displayName: "TestUser",
+        language: lang,
+      };
+      const env = createEnvWithUser(profile);
+      const ctx = mockCtxLang(lang);
+
+      // 1. Should start with name
+      let result = await continueOnboarding(ctx, env, "123", lang);
+      expect(result).toBe(true);
+      let state = await getConversationState(
+        kv as unknown as KVNamespace,
+        "123",
+      );
+      expect(state!.field).toBe("name");
+
+      // 2. After name is shown, next call goes to birthdate
+      result = await continueOnboarding(ctx, env, "123", lang);
+      expect(result).toBe(true);
+      state = await getConversationState(kv as unknown as KVNamespace, "123");
+      expect(state!.field).toBe("birthdate");
+
+      // 3. After birthdate is filled, next call goes to gender
+      profile.birthDate = "1995-03-15";
+      result = await continueOnboarding(ctx, env, "123", lang);
+      expect(result).toBe(true);
+      state = await getConversationState(kv as unknown as KVNamespace, "123");
+      expect(state!.field).toBe("gender");
+
+      // 4. After gender is filled, next call goes to bio
+      profile.gender = "male";
+      result = await continueOnboarding(ctx, env, "123", lang);
+      expect(result).toBe(true);
+      state = await getConversationState(kv as unknown as KVNamespace, "123");
+      expect(state!.field).toBe("bio");
+
+      // 5. After bio is filled, next call goes to location
+      profile.bio = "Hello world";
+      result = await continueOnboarding(ctx, env, "123", lang);
+      expect(result).toBe(true);
+      state = await getConversationState(kv as unknown as KVNamespace, "123");
+      expect(state!.field).toBe("location");
+
+      // 6. After location is filled, next call goes to media
+      profile.location = { city: "Jakarta", country: "Indonesia" };
+      result = await continueOnboarding(ctx, env, "123", lang);
+      expect(result).toBe(true);
+      state = await getConversationState(kv as unknown as KVNamespace, "123");
+      expect(state!.field).toBe("media");
+
+      // 7. After media is filled, next call goes to interests (showOnce)
+      profile.mediaUrls = [
+        { url: "test.jpg", type: "image", uploadedAt: "2024-01-01" },
+      ];
+      result = await continueOnboarding(ctx, env, "123", lang);
+      expect(result).toBe(true);
+      state = await getConversationState(kv as unknown as KVNamespace, "123");
+      expect(state!.field).toBe("interests");
+
+      // 8. After interests is shown, next call goes to phone
+      await kv.put(`onboarding:interests-skipped:123`, "true");
+      result = await continueOnboarding(ctx, env, "123", lang);
+      expect(result).toBe(true);
+      state = await getConversationState(kv as unknown as KVNamespace, "123");
+      expect(state!.field).toBe("phone");
+
+      // 9. After phone is filled, onboarding is complete
+      profile.phoneNumber = "+1234567890";
+      result = await continueOnboarding(ctx, env, "123", lang);
+      expect(result).toBe(false);
+      // Progress should be cleaned up
+      const seenRaw = await kv.get(`onboarding:seen:123`);
+      expect(seenRaw).toBeNull();
+    },
+  );
 });

--- a/services/cf-bot/src/__tests__/handlers.test.ts
+++ b/services/cf-bot/src/__tests__/handlers.test.ts
@@ -110,7 +110,7 @@ describe("Bot Handlers", () => {
       expect(message).toContain("Welcome back");
     });
 
-    it("should prompt incomplete existing user to complete profile", async () => {
+    it("should show language picker for incomplete existing user", async () => {
       const ctx = mockCtx();
       const env = {
         API_SERVICE: createMockApiService({
@@ -124,8 +124,7 @@ describe("Bot Handlers", () => {
       expect(ctx.reply).toHaveBeenCalled();
       const message = (ctx.reply as ReturnType<typeof vi.fn>).mock
         .calls[0][0] as string;
-      expect(message).toContain("Welcome back");
-      expect(message).toContain("incomplete");
+      expect(message).toContain("Choose your language");
     });
   });
 

--- a/services/cf-bot/src/handlers/start.ts
+++ b/services/cf-bot/src/handlers/start.ts
@@ -5,8 +5,15 @@ import {
   ensureUserExists,
   getProfileCompleteness,
   getMissingFieldsDisplay,
+  isPhoneVerified,
+  type UserProfile,
 } from "../lib/user-utils.js";
 import { getMainMenuKeyboard } from "../lib/main-menu.js";
+import {
+  startConversation,
+  continueOnboarding,
+  promptPhoneVerification,
+} from "../lib/conversations.js";
 import { createLogger } from "@meetsmatch/cf-shared";
 
 const log = createLogger("cf-bot");
@@ -110,6 +117,12 @@ export const startCommand = async (ctx: MyContext, env: Env): Promise<void> => {
       return;
     }
 
+    // Profile complete — check phone verification
+    if (!isPhoneVerified(user)) {
+      await promptPhoneVerification(ctx, env, lang);
+      return;
+    }
+
     await ctx.reply(t("welcomeBack", lang), {
       reply_markup: getMainMenuKeyboard(),
       parse_mode: "Markdown",
@@ -143,6 +156,57 @@ export const languageCallback = async (
         parse_mode: "Markdown",
       })
       .catch(() => {});
+
+    // Fetch updated user profile to check completeness
+    const userRes = await env.API_SERVICE.fetch(
+      new Request(`http://api/users/${userId}`, { method: "GET" }),
+    );
+    if (!userRes.ok) {
+      log.warn(
+        "languageCallback",
+        "Failed to fetch user after language update",
+        {
+          userId,
+          status: userRes.status,
+        },
+      );
+      await ctx.reply(t("genericError", selectedLang));
+      return true;
+    }
+
+    const userData = (await userRes.json()) as { user?: UserProfile };
+    const user = userData.user;
+    if (!user) {
+      log.warn(
+        "languageCallback",
+        "User payload missing after language update",
+        {
+          userId,
+        },
+      );
+      await ctx.reply(t("genericError", selectedLang));
+      return true;
+    }
+
+    const { complete, missing } = getProfileCompleteness(user);
+    if (!complete) {
+      // Always start onboarding with name so user can confirm/edit their display name
+      await startConversation(env.KV, userId, "name");
+      const nameKeyboard = {
+        keyboard: [
+          [{ text: t("nameUseTelegramButton", selectedLang) }],
+          [{ text: t("genericCancel", selectedLang) }],
+        ],
+        resize_keyboard: true,
+        one_time_keyboard: true,
+      };
+      await ctx.reply(t("namePrompt", selectedLang), {
+        parse_mode: "Markdown",
+        reply_markup: nameKeyboard,
+      });
+      return true;
+    }
+
     await ctx.reply(t("menuPrompt", selectedLang), {
       reply_markup: getMainMenuKeyboard(),
     });

--- a/services/cf-bot/src/handlers/start.ts
+++ b/services/cf-bot/src/handlers/start.ts
@@ -145,7 +145,14 @@ export const languageCallback = async (
     const userId = String(ctx.from.id);
 
     // Store language preference
-    await setUserLanguage(env, userId, selectedLang);
+    const saved = await setUserLanguage(env, userId, selectedLang);
+    if (!saved) {
+      await ctx
+        .answerCallbackQuery("❌ Failed to set language. Please try again.")
+        .catch(() => {});
+      await ctx.reply(t("genericError", selectedLang));
+      return true;
+    }
 
     await ctx
       .answerCallbackQuery(`Language set to ${getLanguageLabel(selectedLang)}`)

--- a/services/cf-bot/src/handlers/start.ts
+++ b/services/cf-bot/src/handlers/start.ts
@@ -4,15 +4,14 @@ import type { Env } from "../index.js";
 import {
   ensureUserExists,
   getProfileCompleteness,
-  getMissingFieldsDisplay,
   isPhoneVerified,
   type UserProfile,
 } from "../lib/user-utils.js";
 import { getMainMenuKeyboard } from "../lib/main-menu.js";
 import {
-  startConversation,
   continueOnboarding,
   promptPhoneVerification,
+  clearOnboardingProgress,
 } from "../lib/conversations.js";
 import { createLogger } from "@meetsmatch/cf-shared";
 
@@ -50,6 +49,15 @@ async function setUserLanguage(
         body: JSON.stringify({ user: { language } }),
       }),
     );
+    if (!res.ok) {
+      const bodyText = await res.text().catch(() => "<no body>");
+      log.error("setUserLanguage", "API returned error", {
+        userId,
+        language,
+        status: res.status,
+        body: bodyText,
+      });
+    }
     return res.ok;
   } catch (error) {
     log.error(
@@ -95,24 +103,14 @@ export const startCommand = async (ctx: MyContext, env: Env): Promise<void> => {
       }
     }
 
-    if (created) {
-      // New user — show language selection first
+    // For ALL incomplete users (new or existing), show language picker first
+    // so they can choose/change language before onboarding
+    const { complete } = getProfileCompleteness(user);
+
+    if (created || !complete) {
       await ctx.reply(
         "🌍 Choose your language / Pilih bahasa:\n(More languages coming soon!)",
         { reply_markup: buildLanguageKeyboard() },
-      );
-      return;
-    }
-
-    // Existing user — welcome back in their language
-    const { complete, missing } = getProfileCompleteness(user);
-
-    if (!complete) {
-      await ctx.reply(
-        t("welcomeBackIncomplete", lang, {
-          missing: getMissingFieldsDisplay(missing),
-        }),
-        { reply_markup: getMainMenuKeyboard(), parse_mode: "Markdown" },
       );
       return;
     }
@@ -123,6 +121,7 @@ export const startCommand = async (ctx: MyContext, env: Env): Promise<void> => {
       return;
     }
 
+    // Existing complete user — welcome back in their language
     await ctx.reply(t("welcomeBack", lang), {
       reply_markup: getMainMenuKeyboard(),
       parse_mode: "Markdown",
@@ -188,22 +187,30 @@ export const languageCallback = async (
       return true;
     }
 
-    const { complete, missing } = getProfileCompleteness(user);
+    log.info("languageCallback", "Fetched user after language update", {
+      userId,
+      selectedLang,
+      userLanguage: user.language,
+    });
+
+    const { complete } = getProfileCompleteness(user);
     if (!complete) {
-      // Always start onboarding with name so user can confirm/edit their display name
-      await startConversation(env.KV, userId, "name");
-      const nameKeyboard = {
-        keyboard: [
-          [{ text: t("nameUseTelegramButton", selectedLang) }],
-          [{ text: t("genericCancel", selectedLang) }],
-        ],
-        resize_keyboard: true,
-        one_time_keyboard: true,
-      };
-      await ctx.reply(t("namePrompt", selectedLang), {
-        parse_mode: "Markdown",
-        reply_markup: nameKeyboard,
-      });
+      // Clear any previous onboarding progress so the flow restarts fresh
+      // (allows users to change language and re-do onboarding from the beginning)
+      await clearOnboardingProgress(env.KV, userId);
+      // Start onboarding from the first step
+      const continued = await continueOnboarding(
+        ctx,
+        env,
+        userId,
+        selectedLang,
+      );
+      if (continued) return true;
+    }
+
+    // Profile fields complete — check phone verification before showing menu
+    if (!isPhoneVerified(user)) {
+      await promptPhoneVerification(ctx, env, selectedLang);
       return true;
     }
 

--- a/services/cf-bot/src/index.ts
+++ b/services/cf-bot/src/index.ts
@@ -89,12 +89,11 @@ function createBot(env: Env): Bot<MyContext> {
   // Mandatory profile update check — runs before commands and callbacks
   bot.use(async (ctx, next) => {
     if (!ctx.from) return next();
-    // Skip if already in a birthdate conversation
+    // Skip if already in any conversation (let conversation handlers process input)
     const state = await env.KV.get(`conversation:${ctx.from.id}`);
-    if (state) {
-      const parsed = JSON.parse(state) as { field?: string };
-      if (parsed.field === "birthdate") return next();
-    }
+    if (state) return next();
+    // Skip if user is sharing their contact (phone verification in progress)
+    if (ctx.message?.contact) return next();
     const needsUpdate = await checkMandatoryUpdates(ctx, env);
     if (needsUpdate) return;
     return next();

--- a/services/cf-bot/src/index.ts
+++ b/services/cf-bot/src/index.ts
@@ -89,6 +89,12 @@ function createBot(env: Env): Bot<MyContext> {
   // Mandatory profile update check — runs before commands and callbacks
   bot.use(async (ctx, next) => {
     if (!ctx.from) return next();
+    // Skip bot commands (let command handlers show language picker / welcome)
+    if (ctx.message?.text?.startsWith("/")) return next();
+    // Skip language selection callbacks so onboarding doesn't block language persistence
+    if (ctx.callbackQuery?.data?.startsWith("lang:")) return next();
+    // Skip pre-checkout queries (payment flow must not be blocked)
+    if (ctx.preCheckoutQuery) return next();
     // Skip if already in any conversation (let conversation handlers process input)
     const state = await env.KV.get(`conversation:${ctx.from.id}`);
     if (state) return next();

--- a/services/cf-bot/src/lib/__tests__/user-utils.test.ts
+++ b/services/cf-bot/src/lib/__tests__/user-utils.test.ts
@@ -31,7 +31,6 @@ describe("getProfileCompleteness", () => {
       "gender",
       "bio",
       "location",
-      "interests",
       "mediaUrls",
     ]);
   });
@@ -68,7 +67,7 @@ describe("getProfileCompleteness", () => {
     expect(result.missing).toEqual([]);
   });
 
-  it("detects empty interests array", () => {
+  it("allows empty interests array (optional field)", () => {
     const user = {
       id: "1",
       displayName: "Test",
@@ -80,8 +79,8 @@ describe("getProfileCompleteness", () => {
       mediaUrls: [{ url: "test", type: "image", uploadedAt: "2024-01-01" }],
     };
     const result = getProfileCompleteness(user as any);
-    expect(result.complete).toBe(false);
-    expect(result.missing).toContain("interests");
+    expect(result.complete).toBe(true);
+    expect(result.missing).toEqual([]);
   });
 
   it("detects empty displayName", () => {

--- a/services/cf-bot/src/lib/conversations.ts
+++ b/services/cf-bot/src/lib/conversations.ts
@@ -4,6 +4,7 @@ import {
   getProfileCompleteness,
   updateUserProfileComplete,
   parseBirthDate,
+  isPhoneVerified,
   type UserProfile,
 } from "./user-utils.js";
 import { getMainMenuKeyboard } from "./main-menu.js";
@@ -27,6 +28,134 @@ interface ConversationState {
   field: string;
   step: number;
   data?: Record<string, unknown>;
+}
+
+/**
+ * Map profile completeness field names to conversation fields and i18n prompt keys.
+ * Exported so the start handler can use the same mapping.
+ */
+export const FIELD_TO_CONVERSATION = {
+  displayName: { field: "name", promptKey: "namePrompt" as const },
+  birthDate: { field: "birthdate", promptKey: "birthDatePrompt" as const },
+  gender: { field: "gender", promptKey: "genderPrompt" as const },
+  bio: { field: "bio", promptKey: "bioPrompt" as const },
+  location: { field: "location", promptKey: "locationPrompt" as const },
+  interests: { field: "interests", promptKey: "interestsPrompt" as const },
+  mediaUrls: { field: "media", promptKey: "mediaPrompt" as const },
+};
+
+/**
+ * After a profile field is updated, check if there are more missing fields.
+ * If yes, start the next conversation. If no, show the main menu.
+ * Returns true if onboarding continued, false if profile is complete.
+ */
+export async function continueOnboarding(
+  ctx: MyContext,
+  env: Env,
+  userId: string,
+  lang: Language,
+): Promise<boolean> {
+  const user = await getUser(env, userId);
+  if (!user) {
+    await ctx.reply(t("genericError", lang), {
+      reply_markup: getMainMenuKeyboard(),
+    });
+    return true;
+  }
+
+  const { complete, missing } = getProfileCompleteness(user);
+  if (complete) {
+    // Required profile fields complete — offer optional interests before phone check
+    const hasInterests =
+      Array.isArray(user.interests) && user.interests.length > 0;
+    const skippedInterests = await env.KV.get(
+      `onboarding:interests-skipped:${userId}`,
+    );
+    if (!hasInterests && !skippedInterests) {
+      await startConversation(env.KV, userId, "interests");
+      const keyboard = {
+        keyboard: [
+          [{ text: t("interestsSkipButton", lang) }],
+          [{ text: t("genericCancel", lang) }],
+        ],
+        resize_keyboard: true,
+        one_time_keyboard: true,
+      };
+      await ctx.reply(t("interestsPrompt", lang), {
+        parse_mode: "Markdown",
+        reply_markup: keyboard,
+      });
+      return true;
+    }
+
+    // Check phone verification as final step
+    if (!isPhoneVerified(user)) {
+      await promptPhoneVerification(ctx, env, lang);
+      return true;
+    }
+    return false;
+  }
+
+  const firstMissing = missing[0];
+  const mapping =
+    FIELD_TO_CONVERSATION[firstMissing as keyof typeof FIELD_TO_CONVERSATION];
+  if (!mapping) {
+    log.warn("continueOnboarding", "Unknown missing field", { firstMissing });
+    await ctx.reply(t("genericError", lang), {
+      reply_markup: getMainMenuKeyboard(),
+    });
+    return true;
+  }
+
+  await startConversation(env.KV, userId, mapping.field);
+
+  if (firstMissing === "location") {
+    const keyboard = {
+      keyboard: [
+        [{ text: t("locationShareButton", lang), request_location: true }],
+        [{ text: t("locationTypeButton", lang) }],
+        [{ text: t("genericCancel", lang) }],
+      ],
+      resize_keyboard: true,
+      one_time_keyboard: true,
+    };
+    await ctx.reply(t(mapping.promptKey, lang), {
+      parse_mode: "Markdown",
+      reply_markup: keyboard,
+    });
+    return true;
+  }
+
+  if (firstMissing === "gender") {
+    const keyboard = {
+      keyboard: [
+        [
+          { text: t("genderMaleButton", lang) },
+          { text: t("genderFemaleButton", lang) },
+        ],
+        [{ text: t("genericCancel", lang) }],
+      ],
+      resize_keyboard: true,
+      one_time_keyboard: true,
+    };
+    await ctx.reply(t(mapping.promptKey, lang), {
+      parse_mode: "Markdown",
+      reply_markup: keyboard,
+    });
+    return true;
+  }
+
+  // Text fields: provide a Cancel button for consistency
+  const keyboard = {
+    keyboard: [[{ text: t("genericCancel", lang) }]],
+    resize_keyboard: true,
+    one_time_keyboard: true,
+  };
+  await ctx.reply(t(mapping.promptKey, lang), {
+    parse_mode: "Markdown",
+    reply_markup: keyboard,
+  });
+  return true;
 }
 
 const CONVERSATION_TTL_SECONDS = 1800; // 30 minutes
@@ -90,6 +219,18 @@ export async function checkMandatoryUpdates(
           "Enter your birthdate in *DD.MM.YYYY* format (e.g. *15.03.1995*).",
         { parse_mode: "Markdown" },
       );
+      return true;
+    }
+
+    // Check profile completeness and phone verification for all users
+    const { complete } = getProfileCompleteness(user);
+    const lang: Language = (user.language as Language) ?? "en";
+    if (!complete) {
+      await continueOnboarding(ctx, env, userId, lang);
+      return true;
+    }
+    if (!isPhoneVerified(user)) {
+      await promptPhoneVerification(ctx, env, lang);
       return true;
     }
 
@@ -245,14 +386,27 @@ export async function handleConversationMessage(
     return true;
   }
 
+  // Handle optional interests Skip during onboarding
+  if (state.field === "interests" && text === t("interestsSkipButton", lang)) {
+    await clearConversationState(env.KV, userId);
+    await env.KV.put(`onboarding:interests-skipped:${userId}`, "1", {
+      expirationTtl: 2592000, // 30 days
+    });
+    await continueOnboarding(ctx, env, userId, lang);
+    return true;
+  }
+
   // Handle media conversation "Done" button
   if (state.field === "media" && text === t("mediaDoneButton", lang)) {
     await clearConversationState(env.KV, userId);
     const becameComplete = await checkAndUpdateProfileComplete(env, userId);
-    await ctx.reply(t("genericCancelled", lang), {
-      reply_markup: getMainMenuKeyboard(),
-    });
-    if (becameComplete) await promptPhoneVerification(ctx, env, lang);
+    const continued = await continueOnboarding(ctx, env, userId, lang);
+    if (!continued) {
+      await ctx.reply(t("genericCancelled", lang), {
+        reply_markup: getMainMenuKeyboard(),
+      });
+      if (becameComplete) await promptPhoneVerification(ctx, env, lang);
+    }
     return true;
   }
 
@@ -383,11 +537,14 @@ export async function handleLocationMessage(
       env,
       state.userId,
     );
-    await ctx.reply(t("locationUpdated", lang), {
-      reply_markup: getMainMenuKeyboard(),
-    });
-    if (becameComplete) {
-      await promptPhoneVerification(ctx, env, lang);
+    const continued = await continueOnboarding(ctx, env, state.userId, lang);
+    if (!continued) {
+      await ctx.reply(t("locationUpdated", lang), {
+        reply_markup: getMainMenuKeyboard(),
+      });
+      if (becameComplete) {
+        await promptPhoneVerification(ctx, env, lang);
+      }
     }
   } else {
     await ctx.reply(t("genericError", lang), {
@@ -546,11 +703,14 @@ export async function handleMediaMessage(
 
     if (newCount >= 3) {
       await clearConversationState(env.KV, userId);
-      await ctx.reply(
-        t("mediaUploadSuccess", lang, { count: String(newCount) }),
-        { reply_markup: getMainMenuKeyboard() },
-      );
-      if (becameComplete) await promptPhoneVerification(ctx, env, lang);
+      const continued = await continueOnboarding(ctx, env, userId, lang);
+      if (!continued) {
+        await ctx.reply(
+          t("mediaUploadSuccess", lang, { count: String(newCount) }),
+          { reply_markup: getMainMenuKeyboard() },
+        );
+        if (becameComplete) await promptPhoneVerification(ctx, env, lang);
+      }
     } else {
       const keyboard = {
         keyboard: [[{ text: t("mediaDoneButton", lang) }]],
@@ -563,7 +723,7 @@ export async function handleMediaMessage(
           t("mediaDonePrompt", lang),
         { reply_markup: keyboard },
       );
-      if (becameComplete) await promptPhoneVerification(ctx, env, lang);
+      // Don't prompt phone verification yet — let user upload more or tap Done
     }
 
     return true;
@@ -594,10 +754,13 @@ async function handleBioConversation(
       env,
       state.userId,
     );
-    await ctx.reply(t("bioUpdated", lang), {
-      reply_markup: getMainMenuKeyboard(),
-    });
-    if (becameComplete) await promptPhoneVerification(ctx, env, lang);
+    const continued = await continueOnboarding(ctx, env, state.userId, lang);
+    if (!continued) {
+      await ctx.reply(t("bioUpdated", lang), {
+        reply_markup: getMainMenuKeyboard(),
+      });
+      if (becameComplete) await promptPhoneVerification(ctx, env, lang);
+    }
   } else {
     await ctx.reply(t("genericError", lang), {
       reply_markup: getMainMenuKeyboard(),
@@ -627,10 +790,13 @@ async function handleBirthDateConversation(
       env,
       state.userId,
     );
-    await ctx.reply(t("birthDateUpdated", lang), {
-      reply_markup: getMainMenuKeyboard(),
-    });
-    if (becameComplete) await promptPhoneVerification(ctx, env, lang);
+    const continued = await continueOnboarding(ctx, env, state.userId, lang);
+    if (!continued) {
+      await ctx.reply(t("birthDateUpdated", lang), {
+        reply_markup: getMainMenuKeyboard(),
+      });
+      if (becameComplete) await promptPhoneVerification(ctx, env, lang);
+    }
   } else {
     await ctx.reply(t("genericError", lang), {
       reply_markup: getMainMenuKeyboard(),
@@ -646,6 +812,33 @@ async function handleNameConversation(
   text: string,
   lang: Language,
 ): Promise<boolean> {
+  // Handle "Use my Telegram name" button
+  if (text === t("nameUseTelegramButton", lang)) {
+    const telegramName = ctx.from?.first_name ?? "User";
+    const success = await updateUser(env, state.userId, {
+      displayName: telegramName,
+    });
+    await clearConversationState(env.KV, state.userId);
+    if (success) {
+      const becameComplete = await checkAndUpdateProfileComplete(
+        env,
+        state.userId,
+      );
+      const continued = await continueOnboarding(ctx, env, state.userId, lang);
+      if (!continued) {
+        await ctx.reply(t("nameUpdated", lang, { name: telegramName }), {
+          reply_markup: getMainMenuKeyboard(),
+        });
+        if (becameComplete) await promptPhoneVerification(ctx, env, lang);
+      }
+    } else {
+      await ctx.reply(t("genericError", lang), {
+        reply_markup: getMainMenuKeyboard(),
+      });
+    }
+    return true;
+  }
+
   const name = text.trim();
   if (name.length < 1 || name.length > 50) {
     await ctx.reply(t("nameInvalid", lang));
@@ -658,10 +851,13 @@ async function handleNameConversation(
       env,
       state.userId,
     );
-    await ctx.reply(t("nameUpdated", lang, { name }), {
-      reply_markup: getMainMenuKeyboard(),
-    });
-    if (becameComplete) await promptPhoneVerification(ctx, env, lang);
+    const continued = await continueOnboarding(ctx, env, state.userId, lang);
+    if (!continued) {
+      await ctx.reply(t("nameUpdated", lang, { name }), {
+        reply_markup: getMainMenuKeyboard(),
+      });
+      if (becameComplete) await promptPhoneVerification(ctx, env, lang);
+    }
   } else {
     await ctx.reply(t("genericError", lang), {
       reply_markup: getMainMenuKeyboard(),
@@ -677,7 +873,10 @@ async function handleGenderConversation(
   text: string,
   lang: Language,
 ): Promise<boolean> {
-  const genderMap: Record<string, string> = { Male: "male", Female: "female" };
+  const genderMap: Record<string, string> = {
+    [t("genderMaleButton", lang)]: "male",
+    [t("genderFemaleButton", lang)]: "female",
+  };
   const gender = genderMap[text];
   if (!gender) {
     await ctx.reply(t("genderInvalid", lang));
@@ -690,10 +889,13 @@ async function handleGenderConversation(
       env,
       state.userId,
     );
-    await ctx.reply(t("genderUpdated", lang), {
-      reply_markup: getMainMenuKeyboard(),
-    });
-    if (becameComplete) await promptPhoneVerification(ctx, env, lang);
+    const continued = await continueOnboarding(ctx, env, state.userId, lang);
+    if (!continued) {
+      await ctx.reply(t("genderUpdated", lang), {
+        reply_markup: getMainMenuKeyboard(),
+      });
+      if (becameComplete) await promptPhoneVerification(ctx, env, lang);
+    }
   } else {
     await ctx.reply(t("genericError", lang), {
       reply_markup: getMainMenuKeyboard(),
@@ -723,16 +925,23 @@ async function handleInterestsConversation(
   }
   const success = await updateUser(env, state.userId, { interests });
   await clearConversationState(env.KV, state.userId);
+  // Clear any skip flag since user provided interests
+  await env.KV.delete(`onboarding:interests-skipped:${state.userId}`).catch(
+    () => {},
+  );
   if (success) {
     const becameComplete = await checkAndUpdateProfileComplete(
       env,
       state.userId,
     );
-    await ctx.reply(
-      t("interestsUpdated", lang, { interests: interests.join(", ") }),
-      { reply_markup: getMainMenuKeyboard() },
-    );
-    if (becameComplete) await promptPhoneVerification(ctx, env, lang);
+    const continued = await continueOnboarding(ctx, env, state.userId, lang);
+    if (!continued) {
+      await ctx.reply(
+        t("interestsUpdated", lang, { interests: interests.join(", ") }),
+        { reply_markup: getMainMenuKeyboard() },
+      );
+      if (becameComplete) await promptPhoneVerification(ctx, env, lang);
+    }
   } else {
     await ctx.reply(t("genericError", lang), {
       reply_markup: getMainMenuKeyboard(),
@@ -775,13 +984,16 @@ async function handleLocationTextConversation(
         env,
         state.userId,
       );
-      await ctx.reply(
-        `📍 *${escapeMd(city)}, ${escapeMd(country)}* saved!\n\n` +
-          `We could not verify the exact coordinates right now, but your city is recorded. ` +
-          `Distance matching will work once we verify it.`,
-        { parse_mode: "Markdown", reply_markup: getMainMenuKeyboard() },
-      );
-      if (becameComplete) await promptPhoneVerification(ctx, env, lang);
+      const continued = await continueOnboarding(ctx, env, state.userId, lang);
+      if (!continued) {
+        await ctx.reply(
+          `📍 *${escapeMd(city)}, ${escapeMd(country)}* saved!\n\n` +
+            `We could not verify the exact coordinates right now, but your city is recorded. ` +
+            `Distance matching will work once we verify it.`,
+          { parse_mode: "Markdown", reply_markup: getMainMenuKeyboard() },
+        );
+        if (becameComplete) await promptPhoneVerification(ctx, env, lang);
+      }
     } else {
       await ctx.reply(t("genericError", lang), {
         reply_markup: getMainMenuKeyboard(),
@@ -811,11 +1023,14 @@ async function handleLocationTextConversation(
       env,
       state.userId,
     );
-    await ctx.reply(
-      `📍 Location verified: *${escapeMd(normalizedCity)}, ${escapeMd(normalizedCountry)}*`,
-      { parse_mode: "Markdown", reply_markup: getMainMenuKeyboard() },
-    );
-    if (becameComplete) await promptPhoneVerification(ctx, env, lang);
+    const continued = await continueOnboarding(ctx, env, state.userId, lang);
+    if (!continued) {
+      await ctx.reply(
+        `📍 Location verified: *${escapeMd(normalizedCity)}, ${escapeMd(normalizedCountry)}*`,
+        { parse_mode: "Markdown", reply_markup: getMainMenuKeyboard() },
+      );
+      if (becameComplete) await promptPhoneVerification(ctx, env, lang);
+    }
   } else {
     await ctx.reply(t("genericError", lang), {
       reply_markup: getMainMenuKeyboard(),

--- a/services/cf-bot/src/lib/conversations.ts
+++ b/services/cf-bot/src/lib/conversations.ts
@@ -8,7 +8,7 @@ import {
   type UserProfile,
 } from "./user-utils.js";
 import { getMainMenuKeyboard } from "./main-menu.js";
-import { t, type Language, escapeMd } from "./i18n.js";
+import { t, type Language, type Translations, escapeMd } from "./i18n.js";
 import { InlineKeyboard } from "grammy";
 import {
   createLogger,
@@ -45,9 +45,191 @@ export const FIELD_TO_CONVERSATION = {
 };
 
 /**
- * After a profile field is updated, check if there are more missing fields.
- * If yes, start the next conversation. If no, show the main menu.
- * Returns true if onboarding continued, false if profile is complete.
+ * Explicit onboarding step sequence.
+ * Each step defines when it should be shown during onboarding.
+ */
+const ONBOARDING_STEPS: Array<{
+  field: string;
+  promptKey: keyof Translations;
+  showOnce?: boolean;
+  skipIfPresent?: boolean;
+  skipIfVerified?: boolean;
+  keyboardType?: "text" | "gender" | "location" | "interests" | "name";
+}> = [
+  {
+    field: "name",
+    promptKey: "namePrompt",
+    showOnce: true,
+    keyboardType: "name",
+  },
+  {
+    field: "birthdate",
+    promptKey: "birthDatePrompt",
+    skipIfPresent: true,
+    keyboardType: "text",
+  },
+  {
+    field: "gender",
+    promptKey: "genderPrompt",
+    skipIfPresent: true,
+    keyboardType: "gender",
+  },
+  {
+    field: "bio",
+    promptKey: "bioPrompt",
+    skipIfPresent: true,
+    keyboardType: "text",
+  },
+  {
+    field: "location",
+    promptKey: "locationPrompt",
+    skipIfPresent: true,
+    keyboardType: "location",
+  },
+  {
+    field: "media",
+    promptKey: "mediaPrompt",
+    skipIfPresent: true,
+    keyboardType: "text",
+  },
+  {
+    field: "interests",
+    promptKey: "interestsPrompt",
+    showOnce: true,
+    keyboardType: "interests",
+  },
+  {
+    field: "phone",
+    promptKey: "phoneVerifyPrompt",
+    skipIfVerified: true,
+    keyboardType: "text",
+  },
+];
+
+const ONBOARDING_SEEN_TTL = 60 * 60 * 24; // 24 hours
+
+async function getOnboardingSeen(
+  kv: KVNamespace,
+  userId: string,
+): Promise<string[]> {
+  const raw = await kv.get(`onboarding:seen:${userId}`);
+  if (!raw) return [];
+  try {
+    return JSON.parse(raw) as string[];
+  } catch {
+    return [];
+  }
+}
+
+async function markOnboardingSeen(
+  kv: KVNamespace,
+  userId: string,
+  field: string,
+): Promise<void> {
+  const seen = await getOnboardingSeen(kv, userId);
+  if (!seen.includes(field)) {
+    seen.push(field);
+    await kv.put(`onboarding:seen:${userId}`, JSON.stringify(seen), {
+      expirationTtl: ONBOARDING_SEEN_TTL,
+    });
+  }
+}
+
+export async function clearOnboardingProgress(
+  kv: KVNamespace,
+  userId: string,
+): Promise<void> {
+  await kv.delete(`onboarding:seen:${userId}`);
+  await kv.delete(`onboarding:interests-skipped:${userId}`);
+}
+
+function shouldSkipStep(
+  step: (typeof ONBOARDING_STEPS)[number],
+  user: UserProfile,
+  seenFields: string[],
+): boolean {
+  if (step.showOnce && seenFields.includes(step.field)) return true;
+  if (step.skipIfVerified && isPhoneVerified(user)) return true;
+  if (step.skipIfPresent) {
+    switch (step.field) {
+      case "birthdate":
+        return !!user.birthDate && user.birthDate.trim().length > 0;
+      case "gender":
+        return !!user.gender;
+      case "bio":
+        return !!user.bio && user.bio.trim().length > 0;
+      case "location":
+        return (
+          !!user.location && (!!user.location.city || !!user.location.latitude)
+        );
+      case "media":
+        return Array.isArray(user.mediaUrls) && user.mediaUrls.length > 0;
+      default:
+        return false;
+    }
+  }
+  return false;
+}
+
+function buildStepKeyboard(
+  step: (typeof ONBOARDING_STEPS)[number],
+  lang: Language,
+): {
+  keyboard: Array<Array<{ text: string; request_location?: boolean }>>;
+  resize_keyboard: boolean;
+  one_time_keyboard: boolean;
+} {
+  const base = { resize_keyboard: true, one_time_keyboard: true };
+  switch (step.keyboardType) {
+    case "name":
+      return {
+        ...base,
+        keyboard: [
+          [{ text: t("nameUseTelegramButton", lang) }],
+          [{ text: t("genericCancel", lang) }],
+        ],
+      };
+    case "gender":
+      return {
+        ...base,
+        keyboard: [
+          [
+            { text: t("genderMaleButton", lang) },
+            { text: t("genderFemaleButton", lang) },
+          ],
+          [{ text: t("genericCancel", lang) }],
+        ],
+      };
+    case "location":
+      return {
+        ...base,
+        keyboard: [
+          [{ text: t("locationShareButton", lang), request_location: true }],
+          [{ text: t("locationTypeButton", lang) }],
+          [{ text: t("genericCancel", lang) }],
+        ],
+      };
+    case "interests":
+      return {
+        ...base,
+        keyboard: [
+          [{ text: t("interestsSkipButton", lang) }],
+          [{ text: t("genericCancel", lang) }],
+        ],
+      };
+    default:
+      return {
+        ...base,
+        keyboard: [[{ text: t("genericCancel", lang) }]],
+      };
+  }
+}
+
+/**
+ * After a profile field is updated, advance to the next onboarding step.
+ * Uses an explicit step sequence so the flow is predictable:
+ *   name → birthdate → gender → bio → location → media → interests → phone
+ * Returns true if a next step was started, false if onboarding is complete.
  */
 export async function continueOnboarding(
   ctx: MyContext,
@@ -63,99 +245,45 @@ export async function continueOnboarding(
     return true;
   }
 
-  const { complete, missing } = getProfileCompleteness(user);
-  if (complete) {
-    // Required profile fields complete — offer optional interests before phone check
-    const hasInterests =
-      Array.isArray(user.interests) && user.interests.length > 0;
-    const skippedInterests = await env.KV.get(
-      `onboarding:interests-skipped:${userId}`,
+  const seenFields = await getOnboardingSeen(env.KV, userId);
+
+  for (const step of ONBOARDING_STEPS) {
+    if (shouldSkipStep(step, user, seenFields)) continue;
+
+    await startConversation(env.KV, userId, step.field);
+
+    if (step.showOnce) {
+      await markOnboardingSeen(env.KV, userId, step.field);
+    }
+
+    const keyboard = buildStepKeyboard(step, lang);
+    console.log(
+      `[continueOnboarding] userId=${userId} step=${step.field} lang=${lang} keyboard=${JSON.stringify(keyboard)}`,
     );
-    if (!hasInterests && !skippedInterests) {
-      await startConversation(env.KV, userId, "interests");
-      const keyboard = {
+
+    if (step.field === "phone") {
+      // Phone step uses a special contact-sharing keyboard
+      const phoneKeyboard = {
         keyboard: [
-          [{ text: t("interestsSkipButton", lang) }],
-          [{ text: t("genericCancel", lang) }],
+          [{ text: t("phoneVerifyButton", lang), request_contact: true }],
         ],
         resize_keyboard: true,
         one_time_keyboard: true,
       };
-      await ctx.reply(t("interestsPrompt", lang), {
-        parse_mode: "Markdown",
-        reply_markup: keyboard,
-      });
+      await ctx.reply(t(step.promptKey, lang), { reply_markup: phoneKeyboard });
       return true;
     }
 
-    // Check phone verification as final step
-    if (!isPhoneVerified(user)) {
-      await promptPhoneVerification(ctx, env, lang);
-      return true;
-    }
-    return false;
-  }
-
-  const firstMissing = missing[0];
-  const mapping =
-    FIELD_TO_CONVERSATION[firstMissing as keyof typeof FIELD_TO_CONVERSATION];
-  if (!mapping) {
-    log.warn("continueOnboarding", "Unknown missing field", { firstMissing });
-    await ctx.reply(t("genericError", lang), {
-      reply_markup: getMainMenuKeyboard(),
-    });
-    return true;
-  }
-
-  await startConversation(env.KV, userId, mapping.field);
-
-  if (firstMissing === "location") {
-    const keyboard = {
-      keyboard: [
-        [{ text: t("locationShareButton", lang), request_location: true }],
-        [{ text: t("locationTypeButton", lang) }],
-        [{ text: t("genericCancel", lang) }],
-      ],
-      resize_keyboard: true,
-      one_time_keyboard: true,
-    };
-    await ctx.reply(t(mapping.promptKey, lang), {
+    await ctx.reply(t(step.promptKey, lang), {
       parse_mode: "Markdown",
       reply_markup: keyboard,
     });
     return true;
   }
 
-  if (firstMissing === "gender") {
-    const keyboard = {
-      keyboard: [
-        [
-          { text: t("genderMaleButton", lang) },
-          { text: t("genderFemaleButton", lang) },
-        ],
-        [{ text: t("genericCancel", lang) }],
-      ],
-      resize_keyboard: true,
-      one_time_keyboard: true,
-    };
-    await ctx.reply(t(mapping.promptKey, lang), {
-      parse_mode: "Markdown",
-      reply_markup: keyboard,
-    });
-    return true;
-  }
-
-  // Text fields: provide a Cancel button for consistency
-  const keyboard = {
-    keyboard: [[{ text: t("genericCancel", lang) }]],
-    resize_keyboard: true,
-    one_time_keyboard: true,
-  };
-  await ctx.reply(t(mapping.promptKey, lang), {
-    parse_mode: "Markdown",
-    reply_markup: keyboard,
-  });
-  return true;
+  // All steps complete — clean up onboarding tracking
+  await clearOnboardingProgress(env.KV, userId);
+  return false;
 }
 
 const CONVERSATION_TTL_SECONDS = 1800; // 30 minutes
@@ -471,6 +599,10 @@ export async function handleContactMessage(
 
   // Update user with phone number
   const success = await updateUser(env, userId, { phoneNumber });
+  if (success) {
+    // Clear any active phone-verification conversation
+    await clearConversationState(env.KV, userId);
+  }
   await ctx.reply(
     success ? t("phoneVerified", lang) : t("genericError", lang),
     { reply_markup: getMainMenuKeyboard() },

--- a/services/cf-bot/src/lib/i18n.ts
+++ b/services/cf-bot/src/lib/i18n.ts
@@ -11,7 +11,7 @@ export const SUPPORTED_LANGUAGES: {
   { code: "id", label: "Indonesia", flag: "🇮🇩" },
 ];
 
-interface Translations {
+export interface Translations {
   welcomeNew: string;
   welcomeBack: string;
   welcomeBackIncomplete: string;
@@ -553,96 +553,94 @@ const id: Translations = {
     "• Kirim DM tanpa batas\n\n" +
     "Ketuk di bawah untuk upgrade!",
   premiumAdDismiss: "Nanti saja",
-  matchLikeSuccess: "❤️ You liked this profile!",
-  matchDislikeSuccess: "👎 Skipped.",
-  matchSkipSuccess: "⏩ Skipped.",
+  matchLikeSuccess: "❤️ Kamu menyukai profil ini!",
+  matchDislikeSuccess: "👎 Dilewati.",
+  matchSkipSuccess: "⏩ Dilewati.",
   matchLikeLimitReached:
-    "🛑 *Like Limit Reached*\n\nYou've used all your free likes for today.\n\nUpgrade to Premium for unlimited likes, or share your referral link to earn bonus likes!",
+    "🛑 *Batas Like Tercapai*\n\nKamu sudah menggunakan semua like gratis hari ini.\n\nUpgrade ke Premium untuk like tanpa batas, atau bagikan link referal untuk mendapatkan bonus like!",
   matchDislikeLimitReached:
-    "🛑 *Dislike Limit Reached*\n\nYou've used all your free dislikes for today.\n\nUpgrade to Premium for unlimited dislikes, or share your referral link to earn bonus likes!",
-  matchError: "Something went wrong. Please try again.",
+    "🛑 *Batas Dislike Tercapai*\n\nKamu sudah menggunakan semua dislike gratis hari ini.\n\nUpgrade ke Premium untuk dislike tanpa batas, atau bagikan link referal untuk mendapatkan bonus dislike!",
+  matchError: "Terjadi kesalahan. Coba lagi.",
   matchItsAMatch:
-    "🎉 *It's a Match!*\n\n" +
-    "You and *{name}* have liked each other! 💕\n\n" +
-    "Time to start something special ✨",
-  matchStartChatting:
-    "👉 [Start chatting with {name}](https://t.me/{username})",
-  matchSayHiTo: "Say hi to {pronoun} 👋",
+    "🎉 *Match!*\n\n" +
+    "Kamu dan *{name}* saling menyukai! 💕\n\n" +
+    "Saatnya memulai sesuatu yang istimewa ✨",
+  matchStartChatting: "👉 [Mulai chat dengan {name}](https://t.me/{username})",
+  matchSayHiTo: "Say hi ke {pronoun} 👋",
   matchNoUsername:
-    "💬 *{name}* hasn't set a Telegram username yet. You can share yours with them!",
+    "💬 *{name}* belum mengatur username Telegram. Kamu bisa membagikan username-mu!",
   matchesNoMatches:
-    "💑 *No matches yet.*\n\nUse *🔍 Find Match* to discover people, then like someone who likes you back!",
-  matchesMutualMatchesTitle: "💑 You have {count} mutual match(es):",
-  matchesPendingLikesTitle: "💕 {count} person(s) liked you! See them now?",
-  ageRangeSelectMin: "👇 Select *minimum* age:",
-  ageRangeSelectMax: "👇 Select *maximum* age (must be ≥ {min}):",
-  distanceSelect: "👇 Select max distance:",
-  genderPrefSelect: "👇 Select gender preference:",
-  notificationsCheckMatches:
-    "You have {items}! Check them out with *💕 My Matches*.",
+    "💑 *Belum ada match.*\n\nGunakan *🔍 Cari Match* untuk menemukan orang, lalu like seseorang yang juga menyukaimu!",
+  matchesMutualMatchesTitle: "💑 Kamu punya {count} mutual match:",
+  matchesPendingLikesTitle: "💕 {count} orang menyukaimu! Lihat sekarang?",
+  ageRangeSelectMin: "👇 Pilih usia *minimum*:",
+  ageRangeSelectMax: "👇 Pilih usia *maksimum* (harus ≥ {min}):",
+  distanceSelect: "👇 Pilih jarak maksimal:",
+  genderPrefSelect: "👇 Pilih preferensi jenis kelamin:",
+  notificationsCheckMatches: "Kamu punya {items}! Cek di *💕 Match Saya*.",
   dmGated:
-    "🔒 *Direct Messages are a Premium feature*\n\n" +
-    "Send a DM to anyone without waiting for a mutual match.\n\n" +
-    "*Options:*\n" +
-    "• Upgrade to Premium/Premium+ for unlimited DMs\n" +
-    "• Buy 1 DM with Telegram Stars (no subscription)",
-  dmSuccess: "✅ DM unlocked! You can now message *{name}* directly:",
-  dmFailed: "❌ Could not unlock DM. Please try again.",
-  dmError: "❌ Something went wrong. Please try again later.",
-  dmPurchased:
-    "✅ You bought {count} DM credit(s)! You now have {total} DM credit(s).",
+    "🔒 *Direct Message adalah fitur Premium*\n\n" +
+    "Kirim DM ke siapa saja tanpa menunggu mutual match.\n\n" +
+    "*Pilihan:*\n" +
+    "• Upgrade ke Premium/Premium+ untuk DM tanpa batas\n" +
+    "• Beli 1 DM dengan Telegram Stars (tanpa berlangganan)",
+  dmSuccess: "✅ DM terbuka! Kamu sekarang bisa chat *{name}* langsung:",
+  dmFailed: "❌ Gagal membuka DM. Coba lagi.",
+  dmError: "❌ Terjadi kesalahan. Coba lagi nanti.",
+  dmPurchased: "✅ Kamu membeli {count} kredit DM! Total kredit DM: {total}.",
   mediaRequiredPrompt:
-    "📸 *Media Required*\n\nPlease upload at least 1 photo or video to complete your profile.",
-  mediaManagerItemPhoto: "📷 Photo",
+    "📸 *Media Diperlukan*\n\nUnggah minimal 1 foto atau video untuk melengkapi profil.",
+  mediaManagerItemPhoto: "📷 Foto",
   mediaManagerItemVideo: "🎥 Video",
-  mediaManagerDeletePrompt: "Tap an item to delete it, or upload more:",
-  mediaManagerUploadPrompt: "Upload photos or videos to show on your profile:",
-  mediaDeleteSuccess: "✅ Deleted!",
-  mediaDeleteError: "❌ Failed to delete. Please try again.",
+  mediaManagerDeletePrompt:
+    "Ketuk item untuk menghapus, atau unggah lebih banyak:",
+  mediaManagerUploadPrompt: "Unggah foto atau video untuk profilmu:",
+  mediaDeleteSuccess: "✅ Terhapus!",
+  mediaDeleteError: "❌ Gagal menghapus. Coba lagi.",
   matchFallbackNotice:
-    "🔍 *Broadening your search…*\n\nYour current settings are a bit restrictive. Here are some profiles outside your usual preferences — try liking someone new!",
+    "🔍 *Memperluas pencarian…*\n\nPengaturanmu saat ini terlalu ketat. Berikut profil di luar preferensimu — coba like seseorang yang baru!",
   matchAdjustSettingsPrompt:
-    "Tap ⚙️ Settings to adjust your age range, distance, or gender preferences.",
+    "Ketuk ⚙️ Pengaturan untuk mengatur rentang usia, jarak, atau preferensi jenis kelamin.",
   hiddenFromMatches:
-    "👋 Your profile is now hidden from matches. Come back to stay visible!",
-  reportCancelled: "Report cancelled.",
+    "👋 Profilmu sekarang disembunyikan dari match. Kembali untuk tetap terlihat!",
+  reportCancelled: "Laporan dibatalkan.",
   rollbackNoAction:
-    "↩️ Nothing to undo. You haven't taken any action on a profile yet.",
-  rollbackSuccess: "↩️ Undone! The previous profile is back.",
+    "↩️ Tidak ada yang dibatalkan. Kamu belum melakukan aksi apa pun.",
+  rollbackSuccess: "↩️ Berhasil dibatalkan! Profil sebelumnya kembali.",
   rollbackGated:
-    "🔒 *Undo is a Premium+ feature*\n\nUpgrade to Premium or Premium+ to undo your last action!",
-  likeMessageSkipButton: "⏭ Skip",
-  giftTitle: "🎁 *Send a Gift*",
+    "🔒 *Undo adalah fitur Premium+*\n\nUpgrade ke Premium atau Premium+ untuk membatalkan aksi terakhirmu!",
+  likeMessageSkipButton: "⏭ Lewati",
+  giftTitle: "🎁 *Kirim Hadiah*",
   giftSelect:
-    "Choose a gift to send:\n\n🌹 Rose — 10 ⭐\n🍫 Chocolate — 25 ⭐\n🧸 Teddy Bear — 50 ⭐\n💎 Diamond — 100 ⭐",
-  giftSent: "🎁 You sent a *{gift}*! They'll receive it soon.",
-  giftReceived: "🎁 *New Gift!*\n\n{name} sent you a *{gift}*! 💕",
+    "Pilih hadiah yang ingin dikirim:\n\n🌹 Mawar — 10 ⭐\n🍫 Cokelat — 25 ⭐\n🧸 Beruang — 50 ⭐\n💎 Berlian — 100 ⭐",
+  giftSent: "🎁 Kamu mengirim *{gift}*! Mereka akan menerimanya segera.",
+  giftReceived: "🎁 *Hadiah Baru!*\n\n{name} mengirimmu *{gift}*! 💕",
   giftGated:
-    "🔒 *Gifts are a Premium feature*\n\nUpgrade to Premium to send gifts to your matches!",
-  giftCancelled: "Gift cancelled.",
+    "🔒 *Hadiah adalah fitur Premium*\n\nUpgrade ke Premium untuk mengirim hadiah ke match-mu!",
+  giftCancelled: "Hadiah dibatalkan.",
   helpTitle: "🤖 *MeetMatch Bot*",
   helpCommands:
-    "*Commands:*\n*/start* — Get started\n*/profile* — View or edit your profile\n*/match* — Find your next match\n*/matches* — View your matches and likes\n*/settings* — Adjust your preferences\n*/help* — Show this help\n*/about* — About MeetMatch",
+    "*Perintah:*\n*/start* — Mulai\n*/profile* — Lihat atau edit profil\n*/match* — Cari match berikutnya\n*/matches* — Lihat match dan like-mu\n*/settings* — Atur preferensi\n*/help* — Tampilkan bantuan\n*/about* — Tentang MeetMatch",
   helpTips:
-    "*Tips:*\n• Complete your profile for better matches\n• Use */settings* to adjust age range and distance\n• Matches are based on interests, location, and preferences",
-  helpContact: "Need help? Contact support.",
-  aboutTitle: "🌟 *About MeetMatch*",
+    "*Tips:*\n• Lengkapi profil untuk match yang lebih baik\n• Gunakan */settings* untuk mengatur rentang usia dan jarak\n• Match didasarkan pada minat, lokasi, dan preferensi",
+  helpContact: "Butuh bantuan? Hubungi support.",
+  aboutTitle: "🌟 *Tentang MeetMatch*",
   aboutDescription:
-    "MeetMatch helps you find people with similar interests near you.",
-  aboutBuiltWith: "Built with ❤️ using modern tech stack.",
-  aboutVersion: "*Version:* `{version}`",
+    "MeetMatch membantu kamu menemukan orang dengan minat serupa di dekatmu.",
+  aboutBuiltWith: "Dibangun dengan ❤️ menggunakan tech stack modern.",
+  aboutVersion: "*Versi:* `{version}`",
   aboutEnvironment: "*Environment:* {environment}",
-  aboutLastUpdated: "*Last updated:* {builtAt}",
-  aboutServerAge: "*Build age:* {serverAge}",
+  aboutLastUpdated: "*Terakhir diperbarui:* {builtAt}",
+  aboutServerAge: "*Usia build:* {serverAge}",
   premiumPurchased:
-    "✅ You're now on *{tier}*! Enjoy your upgraded experience.",
+    "✅ Kamu sekarang di *{tier}*! Nikmati pengalaman yang ditingkatkan.",
   premiumAdPrompt:
-    "👑 *Unlock Premium Features*\n\n" +
-    "• Unlimited likes & dislikes\n" +
-    "• Skip profiles you don't like\n" +
-    "• See who liked you\n" +
-    "• Send unlimited DMs\n\n" +
-    "Tap below to upgrade!",
+    "👑 *Buka Fitur Premium*\n\n" +
+    "• Like & dislike tanpa batas\n" +
+    "• Lewati profil yang tidak kamu suka\n" +
+    "• Lihat siapa yang menyukaimu\n" +
+    "• Kirim DM tanpa batas\n\n" +
+    "Ketuk di bawah untuk upgrade!",
 };
 
 const dictionaries: Record<Language, Translations> = { en, id };

--- a/services/cf-bot/src/lib/i18n.ts
+++ b/services/cf-bot/src/lib/i18n.ts
@@ -1,4 +1,4 @@
-export type Language = "en";
+export type Language = "en" | "id";
 
 export const DEFAULT_LANGUAGE: Language = "en";
 
@@ -6,7 +6,10 @@ export const SUPPORTED_LANGUAGES: {
   code: Language;
   label: string;
   flag: string;
-}[] = [{ code: "en", label: "English", flag: "🇬🇧" }];
+}[] = [
+  { code: "en", label: "English", flag: "🇬🇧" },
+  { code: "id", label: "Indonesia", flag: "🇮🇩" },
+];
 
 interface Translations {
   welcomeNew: string;
@@ -25,6 +28,10 @@ interface Translations {
   matchDislikeLimitReached: string;
   matchSkipGated: string;
   matchReferralPrompt: string;
+  referralSuccess: string;
+  referralInvalid: string;
+  referralSelf: string;
+  referralAlreadyUsed: string;
   matchError: string;
   matchItsAMatch: string;
   matchStartChatting: string;
@@ -44,14 +51,18 @@ interface Translations {
   ageInvalid: string;
   ageUpdated: string;
   namePrompt: string;
+  nameUseTelegramButton: string;
   nameInvalid: string;
   nameUpdated: string;
   genderPrompt: string;
+  genderMaleButton: string;
+  genderFemaleButton: string;
   genderInvalid: string;
   genderUpdated: string;
   interestsPrompt: string;
   interestsInvalid: string;
   interestsUpdated: string;
+  interestsSkipButton: string;
   locationPrompt: string;
   locationShareButton: string;
   locationTypeButton: string;
@@ -81,6 +92,10 @@ interface Translations {
   genericCancel: string;
   genericCancelled: string;
   fallbackMessage: string;
+  likeReceived: string;
+  mutualMatch: string;
+  notificationsTitle: string;
+  notificationsEmpty: string;
   notificationsNewLikes: string;
   notificationsNewMutual: string;
   notificationsCheckMatches: string;
@@ -114,10 +129,18 @@ interface Translations {
   hiddenFromMatches: string;
   reportPrompt: string;
   reportSubmitted: string;
+  reportError: string;
   reportCancelled: string;
+  feedbackPrompt: string;
+  feedbackSubmitted: string;
+  feedbackError: string;
+  blockConfirm: string;
+  blockSuccess: string;
+  unblockSuccess: string;
   rollbackNoAction: string;
   rollbackSuccess: string;
   rollbackGated: string;
+  matchMessagePrompt: string;
   likeMessagePrompt: string;
   likeMessageSkipButton: string;
   likeMessageSent: string;
@@ -140,6 +163,9 @@ interface Translations {
   aboutLastUpdated: string;
   aboutServerAge: string;
   premiumPurchased: string;
+  premiumTitle: string;
+  premiumSubtitle: string;
+  premiumFeatures: string;
   premiumAdPrompt: string;
   premiumAdDismiss: string;
 }
@@ -173,7 +199,13 @@ const en: Translations = {
     "🔒 *Skip is a Premium feature*\n\nFree users can only Like or Dislike.\n\nUpgrade to Premium to skip profiles and browse faster!",
   matchReferralPrompt:
     "👋 You're on a roll! Share MeetMatch with friends to earn bonus likes and dislikes! 🎁",
+  referralSuccess:
+    "🎉 *Referral successful!*\n\nYou earned *+{bonus}* bonus swipes!",
+  referralInvalid: "❌ Invalid or expired referral code.",
+  referralSelf: "❌ You can't use your own referral code.",
+  referralAlreadyUsed: "❌ You've already used a referral code before.",
   matchError: "Something went wrong. Please try again.",
+  matchMessagePrompt: "✉️ Send a message to your match:",
   matchItsAMatch:
     "🎉 *It's a Match!*\n\n" +
     "You and *{name}* have liked each other! 💕\n\n" +
@@ -204,9 +236,12 @@ const en: Translations = {
   ageUpdated: "✅ Age updated to {age}!",
   namePrompt:
     "What should we call you? Enter your display name (1–50 characters). Type *Cancel* to abort.",
+  nameUseTelegramButton: "👤 Use my Telegram name",
   nameInvalid: "Name must be 1–50 characters. Try again or type *Cancel*.",
   nameUpdated: "✅ Name updated to *{name}*!",
   genderPrompt: "Select your gender:",
+  genderMaleButton: "Male",
+  genderFemaleButton: "Female",
   genderInvalid:
     "Invalid selection. Please choose *Male* or *Female*, or type *Cancel*.",
   genderUpdated: "✅ Gender updated!",
@@ -214,6 +249,7 @@ const en: Translations = {
     "What are you into? Enter your interests separated by commas (max 10). Type *Cancel* to abort.",
   interestsInvalid:
     "Please enter at least one interest, separated by commas. Try again or type *Cancel*.",
+  interestsSkipButton: "⏭️ Skip",
   interestsUpdated: "✅ Interests updated: *{interests}*!",
   locationPrompt: "How would you like to set your location?",
   locationShareButton: "📍 Share my location",
@@ -256,6 +292,10 @@ const en: Translations = {
   genericCancelled: "Cancelled.",
   fallbackMessage:
     "I'm not sure what you mean. Use the menu below or try /help for guidance.",
+  likeReceived: "❤️ Someone liked you!",
+  mutualMatch: "🎉 *It's a Match!* You and {name} liked each other!",
+  notificationsTitle: "🔔 *Notifications*",
+  notificationsEmpty: "No new notifications.",
   notificationsNewLikes: "❤️ new like(s)",
   notificationsNewMutual: "💕 new mutual match(es)",
   notificationsCheckMatches:
@@ -308,7 +348,15 @@ const en: Translations = {
     "⚠️ *Report Profile*\n\nWhy are you reporting this profile? Type your reason below, or tap *Cancel*.",
   reportSubmitted:
     "✅ Report submitted. Thank you for keeping our community safe.",
+  reportError: "❌ Failed to submit report. Please try again.",
   reportCancelled: "Report cancelled.",
+  feedbackPrompt:
+    "💬 *Feedback*\n\nWhat suggestions or feedback do you have? Type *Cancel* to abort.",
+  feedbackSubmitted: "✅ Feedback submitted. Thank you!",
+  feedbackError: "❌ Failed to submit feedback. Please try again.",
+  blockConfirm: "Are you sure you want to block this user?",
+  blockSuccess: "✅ User blocked.",
+  unblockSuccess: "✅ User unblocked.",
   rollbackNoAction:
     "↩️ Nothing to undo. You haven't taken any action on a profile yet.",
   rollbackSuccess: "↩️ Undone! The previous profile is back.",
@@ -343,6 +391,14 @@ const en: Translations = {
   aboutServerAge: "*Build age:* {serverAge}",
   premiumPurchased:
     "✅ You're now on *{tier}*! Enjoy your upgraded experience.",
+  premiumTitle: "👑 *Premium*",
+  premiumSubtitle: "Unlock exclusive features with Premium:",
+  premiumFeatures:
+    "• Unlimited likes & dislikes\n" +
+    "• Skip profiles you don't like\n" +
+    "• See who liked you\n" +
+    "• Send unlimited DMs\n\n" +
+    "Tap below to upgrade!",
   premiumAdPrompt:
     "👑 *Unlock Premium Features*\n\n" +
     "• Unlimited likes & dislikes\n" +
@@ -353,7 +409,243 @@ const en: Translations = {
   premiumAdDismiss: "Maybe later",
 };
 
-const dictionaries: Record<Language, Translations> = { en };
+const id: Translations = {
+  welcomeNew:
+    "👋 *Selamat datang di MeetMatch!*\n\n" +
+    "Saya di sini untuk membantu kamu menemukan koneksi yang bermakna dengan orang-orang yang memiliki minat serupa.\n\n" +
+    "Mari mulai — ketuk *👤 Profil* di bawah untuk mengatur profilmu, lalu temukan match!",
+  welcomeBack: "👋 *Selamat datang kembali!*",
+  welcomeBackIncomplete:
+    "👋 *Selamat datang kembali!*\n\nProfilmu belum lengkap. Yang kurang: {missing}\n\nKetuk *👤 Profil* untuk melengkapi.",
+  profileTitle: "👤 *Profilmu*",
+  profileIncompleteWarning:
+    "⚠️ Profilmu belum lengkap. Lengkapi profil untuk mulai mencari match.",
+  profileSelectField: "Pilih bagian profil yang ingin diubah:",
+  matchProfileIncomplete:
+    "⚠️ Profilmu belum lengkap. Lengkapi dulu ya sebelum mencari match.",
+  matchFinding: "🔍 Mencari match untukmu...",
+  matchNoMatches:
+    "😕 Belum ada match saat ini. Coba lagi nanti atau ubah preferensi match-mu di *⚙️ Pengaturan*.",
+  matchSkipGated: "Kamu sudah mencapai batas swipe harian. Coba lagi besok!",
+  matchReferralPrompt:
+    "🎁 *Undang Teman*\n\n" +
+    "Bagikan kode referalmu dan dapatkan bonus swipe!\n\n" +
+    "Kode referalmu: `{code}`",
+  referralSuccess:
+    "🎉 *Referal berhasil!*\n\n" + "Kamu mendapatkan *+{bonus}* swipe bonus!",
+  referralInvalid: "❌ Kode referal tidak valid atau sudah kadaluarsa.",
+  referralSelf: "❌ Kamu tidak bisa menggunakan kode referalmu sendiri.",
+  referralAlreadyUsed:
+    "❌ Kamu sudah pernah menggunakan kode referal sebelumnya.",
+  settingsTitle: "⚙️ *Pengaturan*",
+  bioPrompt:
+    "Ceritakan tentang dirimu! Masukkan bio (maks 300 karakter). Ketik *Batal* untuk membatalkan.",
+  bioTooLong:
+    "Bio terlalu panjang. Maksimal 300 karakter. Coba lagi atau ketik *Batal*.",
+  bioUpdated: "✅ Bio diperbarui!",
+  birthDatePrompt:
+    "Kapan tanggal lahirmu? Masukkan tanggal lahir dalam format *DD.MM.YYYY* (contoh: *15.03.1995*). Ketik *Batal* untuk membatalkan.",
+  birthDateInvalid:
+    "Tanggal tidak valid. Gunakan format *DD.MM.YYYY* dan pastikan tanggalnya nyata antara 12–80 tahun yang lalu. Coba lagi atau ketik *Batal*.",
+  birthDateUpdated: "✅ Tanggal lahir diperbarui!",
+  agePrompt:
+    "Berapa umurmu? Masukkan umur (12–80). Ketik *Batal* untuk membatalkan.",
+  ageInvalid:
+    "Umur tidak valid. Harus antara 12–80. Coba lagi atau ketik *Batal*.",
+  ageUpdated: "✅ Umur diperbarui menjadi {age}!",
+  namePrompt:
+    "Siapa nama panggilanmu? Masukkan nama tampilan (1–50 karakter). Ketik *Batal* untuk membatalkan.",
+  nameUseTelegramButton: "👤 Gunakan nama Telegram",
+  nameInvalid: "Nama harus 1–50 karakter. Coba lagi atau ketik *Batal*.",
+  nameUpdated: "✅ Nama diperbarui menjadi *{name}*!",
+  genderPrompt: "Pilih jenis kelamin:",
+  genderMaleButton: "Laki-laki",
+  genderFemaleButton: "Perempuan",
+  genderInvalid:
+    "Pilihan tidak valid. Pilih *Laki-laki* atau *Perempuan*, atau ketik *Batal*.",
+  genderUpdated: "✅ Jenis kelamin diperbarui!",
+  interestsPrompt:
+    "Apa minatmu? Masukkan minat yang dipisahkan koma (maks 10). Ketik *Batal* untuk membatalkan.",
+  interestsInvalid:
+    "Masukkan setidaknya satu minat, dipisahkan koma. Coba lagi atau ketik *Batal*.",
+  interestsUpdated: "✅ Minat diperbarui!",
+  interestsSkipButton: "⏭️ Lewati",
+  locationPrompt: "Bagaimana cara mengatur lokasimu?",
+  locationShareButton: "📍 Bagikan lokasiku",
+  locationTypeButton: "⌨️ Ketik kota & negara",
+  locationTypePrompt:
+    "Masukkan kota dan negara dipisahkan koma (contoh: *Jakarta, Indonesia*). Ketik *Batal* untuk membatalkan.",
+  locationUpdated: "✅ Lokasi diperbarui!",
+  locationInvalid: "Lokasi tidak valid. Coba lagi atau ketik *Batal*.",
+  ageRangePrompt:
+    "Rentang usia match yang diinginkan? Masukkan format *min-max* (contoh: *18-25*). Ketik *Batal* untuk membatalkan.",
+  ageRangeInvalid:
+    "Rentang usia tidak valid. Gunakan format *min-max* (contoh: *18-25*). Coba lagi atau ketik *Batal*.",
+  ageRangeUpdated: "✅ Rentang usia diperbarui!",
+  distancePrompt:
+    "Jarak maksimal match (km)? Masukkan angka (5–500). Ketik *Batal* untuk membatalkan.",
+  distanceInvalid:
+    "Jarak tidak valid. Harus antara 5–500 km. Coba lagi atau ketik *Batal*.",
+  distanceUpdated: "✅ Jarak diperbarui!",
+  genderPrefPrompt:
+    "Jenis kelamin match yang diinginkan? Pilih atau masukkan dipisahkan koma (*laki-laki, perempuan, lainnya*). Ketik *Batal* untuk membatalkan.",
+  genderPrefInvalid:
+    "Jenis kelamin tidak valid. Pilih *laki-laki, perempuan, lainnya*. Coba lagi atau ketik *Batal*.",
+  genderPrefUpdated: "✅ Preferensi jenis kelamin diperbarui!",
+  phoneVerifyPrompt:
+    "📱 *Satu langkah lagi* — verifikasi nomor teleponmu untuk membangun kepercayaan dengan match-mu.\n\n" +
+    "Ketuk tombol di bawah untuk membagikan kontakmu. Nomormu hanya terlihat oleh match yang saling suka.",
+  phoneVerifyButton: "📲 Bagikan kontakku",
+  phoneVerified:
+    "✅ Nomor telepon terverifikasi! Profilmu sekarang lengkap. Gunakan *🔍 Cari Match* untuk mulai menemukan orang!",
+  phoneSkipped:
+    "⚠️ Verifikasi telepon dilewati. Kamu bisa verifikasi nanti di pengaturan.",
+  phoneShareOwn: "❌ Harap bagikan kontakmu sendiri.",
+  phoneFailed: "Tidak bisa mendapatkan nomor telepon. Coba lagi.",
+  reportPrompt: "Apa alasan laporan? Ketik *Batal* untuk membatalkan.",
+  reportSubmitted: "✅ Laporan dikirim. Terima kasih!",
+  reportError: "❌ Gagal mengirim laporan. Coba lagi.",
+  feedbackPrompt:
+    "💬 *Umpan Balik*\n\nApa saran atau masukanmu? Ketik *Batal* untuk membatalkan.",
+  feedbackSubmitted: "✅ Umpan balik dikirim. Terima kasih!",
+  feedbackError: "❌ Gagal mengirim umpan balik. Coba lagi.",
+  blockConfirm: "Apakah kamu yakin ingin memblokir pengguna ini?",
+  blockSuccess: "✅ Pengguna diblokir.",
+  unblockSuccess: "✅ Blokir dibatalkan.",
+  mediaPrompt:
+    "Kirimkan 1–3 foto atau video untuk profilmu. Ketuk 📎 untuk melampirkan.",
+  mediaInvalidType: "❌ Tipe file tidak didukung. Kirim foto atau video.",
+  mediaMaxReached: "❌ Maksimal {count}/3 media tercapai.",
+  mediaUploadSuccess: "✅ Media diunggah! Sekarang kamu punya {count}/3.",
+  mediaUploadError: "❌ Gagal mengunggah media. Coba lagi.",
+  mediaDonePrompt: "Kirim lebih banyak atau ketuk ✅ Selesai jika sudah.",
+  mediaDoneButton: "✅ Selesai",
+  mediaAddMoreButton: "📤 Tambah lagi",
+  mediaDeletedCleanup: "🗑️ Media dihapus dari profil.",
+  mediaManagerEmpty: "📸 *Manajer Media*\n\nBelum ada media di profilmu.",
+  mediaManagerTitle: "📸 *Manajer Media*\n\nMedia profilmu:",
+  mediaLimitReached:
+    "❌ *Batas unggahan tercapai!*\n\n" +
+    "Kamu sudah mencapai batas unggahan harian.\n\n" +
+    "🎁 *Dapatkan lebih banyak* dengan mengundang teman atau upgrade ke Premium!",
+  mediaRetryPrompt: "❌ Gagal mengunggah. Coba lagi?",
+  notificationsTitle: "🔔 *Notifikasi*",
+  notificationsEmpty: "Tidak ada notifikasi baru.",
+  likeReceived: "❤️ Seseorang menyukaimu!",
+  mutualMatch: "🎉 *Match baru!* Kamu dan {name} saling menyukai!",
+  matchMessagePrompt: "✉️ Kirim pesan ke match-mu:",
+  likeMessagePrompt: "💌 Tambahkan pesan dengan like-mu:",
+  likeMessageSent: "✅ Pesan dan like terkirim!",
+  menuPrompt: "Ada yang bisa saya bantu?",
+  genericError: "❌ Maaf, terjadi kesalahan. Coba lagi nanti.",
+  genericCancel: "Batal",
+  genericCancelled: "Dibatalkan.",
+  fallbackMessage:
+    "Saya tidak mengerti maksudmu. Gunakan menu di bawah atau coba /help untuk panduan.",
+  notificationsNewLikes: "❤️ {count} orang menyukaimu!",
+  notificationsNewMutual: "🎉 Match baru dengan {name}!",
+  premiumTitle: "👑 *Premium*",
+  premiumSubtitle: "Akses fitur eksklusif dengan Premium:",
+  premiumFeatures:
+    "• Suka & tidak suka tanpa batas\n" +
+    "• Lewati profil yang tidak kamu suka\n" +
+    "• Lihat siapa yang menyukaimu\n" +
+    "• Kirim DM tanpa batas\n\n" +
+    "Ketuk di bawah untuk upgrade!",
+  premiumAdDismiss: "Nanti saja",
+  matchLikeSuccess: "❤️ You liked this profile!",
+  matchDislikeSuccess: "👎 Skipped.",
+  matchSkipSuccess: "⏩ Skipped.",
+  matchLikeLimitReached:
+    "🛑 *Like Limit Reached*\n\nYou've used all your free likes for today.\n\nUpgrade to Premium for unlimited likes, or share your referral link to earn bonus likes!",
+  matchDislikeLimitReached:
+    "🛑 *Dislike Limit Reached*\n\nYou've used all your free dislikes for today.\n\nUpgrade to Premium for unlimited dislikes, or share your referral link to earn bonus likes!",
+  matchError: "Something went wrong. Please try again.",
+  matchItsAMatch:
+    "🎉 *It's a Match!*\n\n" +
+    "You and *{name}* have liked each other! 💕\n\n" +
+    "Time to start something special ✨",
+  matchStartChatting:
+    "👉 [Start chatting with {name}](https://t.me/{username})",
+  matchSayHiTo: "Say hi to {pronoun} 👋",
+  matchNoUsername:
+    "💬 *{name}* hasn't set a Telegram username yet. You can share yours with them!",
+  matchesNoMatches:
+    "💑 *No matches yet.*\n\nUse *🔍 Find Match* to discover people, then like someone who likes you back!",
+  matchesMutualMatchesTitle: "💑 You have {count} mutual match(es):",
+  matchesPendingLikesTitle: "💕 {count} person(s) liked you! See them now?",
+  ageRangeSelectMin: "👇 Select *minimum* age:",
+  ageRangeSelectMax: "👇 Select *maximum* age (must be ≥ {min}):",
+  distanceSelect: "👇 Select max distance:",
+  genderPrefSelect: "👇 Select gender preference:",
+  notificationsCheckMatches:
+    "You have {items}! Check them out with *💕 My Matches*.",
+  dmGated:
+    "🔒 *Direct Messages are a Premium feature*\n\n" +
+    "Send a DM to anyone without waiting for a mutual match.\n\n" +
+    "*Options:*\n" +
+    "• Upgrade to Premium/Premium+ for unlimited DMs\n" +
+    "• Buy 1 DM with Telegram Stars (no subscription)",
+  dmSuccess: "✅ DM unlocked! You can now message *{name}* directly:",
+  dmFailed: "❌ Could not unlock DM. Please try again.",
+  dmError: "❌ Something went wrong. Please try again later.",
+  dmPurchased:
+    "✅ You bought {count} DM credit(s)! You now have {total} DM credit(s).",
+  mediaRequiredPrompt:
+    "📸 *Media Required*\n\nPlease upload at least 1 photo or video to complete your profile.",
+  mediaManagerItemPhoto: "📷 Photo",
+  mediaManagerItemVideo: "🎥 Video",
+  mediaManagerDeletePrompt: "Tap an item to delete it, or upload more:",
+  mediaManagerUploadPrompt: "Upload photos or videos to show on your profile:",
+  mediaDeleteSuccess: "✅ Deleted!",
+  mediaDeleteError: "❌ Failed to delete. Please try again.",
+  matchFallbackNotice:
+    "🔍 *Broadening your search…*\n\nYour current settings are a bit restrictive. Here are some profiles outside your usual preferences — try liking someone new!",
+  matchAdjustSettingsPrompt:
+    "Tap ⚙️ Settings to adjust your age range, distance, or gender preferences.",
+  hiddenFromMatches:
+    "👋 Your profile is now hidden from matches. Come back to stay visible!",
+  reportCancelled: "Report cancelled.",
+  rollbackNoAction:
+    "↩️ Nothing to undo. You haven't taken any action on a profile yet.",
+  rollbackSuccess: "↩️ Undone! The previous profile is back.",
+  rollbackGated:
+    "🔒 *Undo is a Premium+ feature*\n\nUpgrade to Premium or Premium+ to undo your last action!",
+  likeMessageSkipButton: "⏭ Skip",
+  giftTitle: "🎁 *Send a Gift*",
+  giftSelect:
+    "Choose a gift to send:\n\n🌹 Rose — 10 ⭐\n🍫 Chocolate — 25 ⭐\n🧸 Teddy Bear — 50 ⭐\n💎 Diamond — 100 ⭐",
+  giftSent: "🎁 You sent a *{gift}*! They'll receive it soon.",
+  giftReceived: "🎁 *New Gift!*\n\n{name} sent you a *{gift}*! 💕",
+  giftGated:
+    "🔒 *Gifts are a Premium feature*\n\nUpgrade to Premium to send gifts to your matches!",
+  giftCancelled: "Gift cancelled.",
+  helpTitle: "🤖 *MeetMatch Bot*",
+  helpCommands:
+    "*Commands:*\n*/start* — Get started\n*/profile* — View or edit your profile\n*/match* — Find your next match\n*/matches* — View your matches and likes\n*/settings* — Adjust your preferences\n*/help* — Show this help\n*/about* — About MeetMatch",
+  helpTips:
+    "*Tips:*\n• Complete your profile for better matches\n• Use */settings* to adjust age range and distance\n• Matches are based on interests, location, and preferences",
+  helpContact: "Need help? Contact support.",
+  aboutTitle: "🌟 *About MeetMatch*",
+  aboutDescription:
+    "MeetMatch helps you find people with similar interests near you.",
+  aboutBuiltWith: "Built with ❤️ using modern tech stack.",
+  aboutVersion: "*Version:* `{version}`",
+  aboutEnvironment: "*Environment:* {environment}",
+  aboutLastUpdated: "*Last updated:* {builtAt}",
+  aboutServerAge: "*Build age:* {serverAge}",
+  premiumPurchased:
+    "✅ You're now on *{tier}*! Enjoy your upgraded experience.",
+  premiumAdPrompt:
+    "👑 *Unlock Premium Features*\n\n" +
+    "• Unlimited likes & dislikes\n" +
+    "• Skip profiles you don't like\n" +
+    "• See who liked you\n" +
+    "• Send unlimited DMs\n\n" +
+    "Tap below to upgrade!",
+};
+
+const dictionaries: Record<Language, Translations> = { en, id };
 
 export function escapeMd(value: string): string {
   return value.replace(/[_*\[\]`\\]/g, "\\$&");

--- a/services/cf-bot/src/lib/user-utils.ts
+++ b/services/cf-bot/src/lib/user-utils.ts
@@ -82,9 +82,6 @@ export function getProfileCompleteness(user: UserProfile): {
   if (!user.location || (!user.location.city && !user.location.latitude)) {
     missing.push("location");
   }
-  if (!user.interests || user.interests.length === 0) {
-    missing.push("interests");
-  }
   if (!user.mediaUrls || user.mediaUrls.length === 0) {
     missing.push("mediaUrls");
   }

--- a/services/cf-bot/src/menus/profile.ts
+++ b/services/cf-bot/src/menus/profile.ts
@@ -41,31 +41,74 @@ export async function handleProfileCallback(
   }
 
   switch (data) {
-    case "profile:bio":
+    case "profile:bio": {
       await startConversation(env.KV, userId, "bio");
-      await ctx.reply(t("bioPrompt", lang));
+      const bioKeyboard = {
+        keyboard: [[{ text: t("genericCancel", lang) }]],
+        resize_keyboard: true,
+        one_time_keyboard: true,
+      };
+      await ctx.reply(t("bioPrompt", lang), { reply_markup: bioKeyboard });
       await ctx.answerCallbackQuery().catch(() => {});
       return true;
-    case "profile:birthdate":
+    }
+    case "profile:birthdate": {
       await startConversation(env.KV, userId, "birthdate");
-      await ctx.reply(t("birthDatePrompt", lang));
+      const birthKeyboard = {
+        keyboard: [[{ text: t("genericCancel", lang) }]],
+        resize_keyboard: true,
+        one_time_keyboard: true,
+      };
+      await ctx.reply(t("birthDatePrompt", lang), {
+        reply_markup: birthKeyboard,
+      });
       await ctx.answerCallbackQuery().catch(() => {});
       return true;
-    case "profile:name":
+    }
+    case "profile:name": {
       await startConversation(env.KV, userId, "name");
-      await ctx.reply(t("namePrompt", lang));
+      const nameKeyboard = {
+        keyboard: [
+          [{ text: t("nameUseTelegramButton", lang) }],
+          [{ text: t("genericCancel", lang) }],
+        ],
+        resize_keyboard: true,
+        one_time_keyboard: true,
+      };
+      await ctx.reply(t("namePrompt", lang), { reply_markup: nameKeyboard });
       await ctx.answerCallbackQuery().catch(() => {});
       return true;
-    case "profile:gender":
+    }
+    case "profile:gender": {
       await startConversation(env.KV, userId, "gender");
-      await ctx.reply(t("genderPrompt", lang));
+      const keyboard = {
+        keyboard: [
+          [
+            { text: t("genderMaleButton", lang) },
+            { text: t("genderFemaleButton", lang) },
+          ],
+          [{ text: t("genericCancel", lang) }],
+        ],
+        resize_keyboard: true,
+        one_time_keyboard: true,
+      };
+      await ctx.reply(t("genderPrompt", lang), { reply_markup: keyboard });
       await ctx.answerCallbackQuery().catch(() => {});
       return true;
-    case "profile:interests":
+    }
+    case "profile:interests": {
       await startConversation(env.KV, userId, "interests");
-      await ctx.reply(t("interestsPrompt", lang));
+      const interestsKeyboard = {
+        keyboard: [[{ text: t("genericCancel", lang) }]],
+        resize_keyboard: true,
+        one_time_keyboard: true,
+      };
+      await ctx.reply(t("interestsPrompt", lang), {
+        reply_markup: interestsKeyboard,
+      });
       await ctx.answerCallbackQuery().catch(() => {});
       return true;
+    }
     case "profile:location": {
       await startConversation(env.KV, userId, "location");
       const keyboard = {


### PR DESCRIPTION
## Problem
After a new user selects their language via the inline keyboard, the bot immediately shows the main menu without checking if the profile is complete. This causes new users to bypass profile creation entirely and land on an empty profile.

## Fix
- After setting the language preference, fetch the updated user profile from the API
- Check profile completeness via `getProfileCompleteness()`
- If incomplete, start the `name` conversation and prompt the user for their display name
- The natural conversation flow then continues: name → birthdate → gender → bio → location → interests → media

## Testing
- [ ] Dev deployment: test fresh user onboarding flow
- [ ] Verify profile creation steps are not skipped
- [ ] CI passes (lint, typecheck, tests)

## Related
Prod bug: after choosing language, profile creation was bypassed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Indonesian (Bahasa Indonesia) language support.
  * Explicit onboarding orchestration to resume step-by-step flows and continue across steps.

* **Improvements**
  * Onboarding now offers language selection first for incomplete profiles and gates phone verification until required fields complete.
  * “Use my Telegram name” option and inline keyboard controls (cancel/skip) across profile prompts.

* **Bug Fixes**
  * Empty interests no longer mark profiles incomplete.

* **Tests**
  * Added regression tests covering multi-language onboarding flows and skip behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/irfndi/meets-match/pull/135?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->