### PR TITLE
fix: don't log 404 as error in ensureUserExists

### DIFF
--- a/services/cf-bot/src/lib/__tests__/user-utils.test.ts
+++ b/services/cf-bot/src/lib/__tests__/user-utils.test.ts
@@ -16,13 +16,12 @@ function mockCtx(overrides: Partial<MyContext> = {}): MyContext {
 }
 
 function createMockApiService(responseMap: Record<string, () => Response>) {
+  const sortedPatterns = Object.entries(responseMap).sort(
+    (a, b) => b[0].length - a[0].length,
+  );
   return {
-    fetch: vi.fn().mockImplementation((req: Request) => {
-      const url =
-        typeof req === "string" ? req : (req as any).url || String(req);
-      const sortedPatterns = Object.entries(responseMap).sort(
-        (a, b) => b[0].length - a[0].length,
-      );
+    fetch: vi.fn().mockImplementation((req: Request | string) => {
+      const url = typeof req === "string" ? req : req.url;
       for (const [pattern, factory] of sortedPatterns) {
         if (url.includes(pattern)) {
           return Promise.resolve(factory());
@@ -224,10 +223,9 @@ describe("ensureUserExists", () => {
     expect(result!.user.id).toBe("123");
     expect(result!.created).toBe(true);
     expect(consoleErrorSpy).not.toHaveBeenCalled();
-    expect(consoleLogSpy).toHaveBeenCalled();
-    const logEntry = JSON.parse(consoleLogSpy.mock.calls[0][0]);
-    expect(logEntry.level).toBe("info");
-    expect(logEntry.message).toBe("User not found, will create");
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      expect.stringContaining("User not found, will create"),
+    );
   });
 
   it("logs error for non-404 API failures", async () => {
@@ -252,10 +250,10 @@ describe("ensureUserExists", () => {
     expect(result).not.toBeNull();
     expect(result!.created).toBe(true);
     expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
-    const logEntry = JSON.parse(consoleErrorSpy.mock.calls[0][0]);
-    expect(logEntry.level).toBe("error");
-    expect(logEntry.message).toBe(
-      "Failed to fetch existing user, will try create",
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Failed to fetch existing user, will try create",
+      ),
     );
   });
 

--- a/services/cf-bot/src/lib/__tests__/user-utils.test.ts
+++ b/services/cf-bot/src/lib/__tests__/user-utils.test.ts
@@ -164,7 +164,9 @@ describe("getMissingFieldsDisplay", () => {
 });
 
 describe("ensureUserExists", () => {
-  const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  const consoleErrorSpy = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
   const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
   beforeEach(() => {
@@ -182,9 +184,12 @@ describe("ensureUserExists", () => {
     const env = {
       API_SERVICE: createMockApiService({
         "/users/123": () =>
-          new Response(JSON.stringify({ user: { id: "123", displayName: "Test" } }), {
-            status: 200,
-          }),
+          new Response(
+            JSON.stringify({ user: { id: "123", displayName: "Test" } }),
+            {
+              status: 200,
+            },
+          ),
       }),
     } as any;
 
@@ -201,11 +206,15 @@ describe("ensureUserExists", () => {
     const ctx = mockCtx();
     const env = {
       API_SERVICE: createMockApiService({
-        "/users/123": () => new Response(JSON.stringify({ error: "Not found" }), { status: 404 }),
+        "/users/123": () =>
+          new Response(JSON.stringify({ error: "Not found" }), { status: 404 }),
         "/users": () =>
-          new Response(JSON.stringify({ user: { id: "123", displayName: "Test" } }), {
-            status: 200,
-          }),
+          new Response(
+            JSON.stringify({ user: { id: "123", displayName: "Test" } }),
+            {
+              status: 200,
+            },
+          ),
       }),
     } as any;
 
@@ -225,11 +234,15 @@ describe("ensureUserExists", () => {
     const ctx = mockCtx();
     const env = {
       API_SERVICE: createMockApiService({
-        "/users/123": () => new Response(JSON.stringify({ error: "DB down" }), { status: 500 }),
+        "/users/123": () =>
+          new Response(JSON.stringify({ error: "DB down" }), { status: 500 }),
         "/users": () =>
-          new Response(JSON.stringify({ user: { id: "123", displayName: "Test" } }), {
-            status: 200,
-          }),
+          new Response(
+            JSON.stringify({ user: { id: "123", displayName: "Test" } }),
+            {
+              status: 200,
+            },
+          ),
       }),
     } as any;
 
@@ -241,15 +254,19 @@ describe("ensureUserExists", () => {
     expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
     const logEntry = JSON.parse(consoleErrorSpy.mock.calls[0][0]);
     expect(logEntry.level).toBe("error");
-    expect(logEntry.message).toBe("Failed to fetch existing user, will try create");
+    expect(logEntry.message).toBe(
+      "Failed to fetch existing user, will try create",
+    );
   });
 
   it("returns null when both getUser and createUser fail", async () => {
     const ctx = mockCtx();
     const env = {
       API_SERVICE: createMockApiService({
-        "/users/123": () => new Response(JSON.stringify({ error: "DB down" }), { status: 500 }),
-        "/users": () => new Response(JSON.stringify({ error: "DB down" }), { status: 500 }),
+        "/users/123": () =>
+          new Response(JSON.stringify({ error: "DB down" }), { status: 500 }),
+        "/users": () =>
+          new Response(JSON.stringify({ error: "DB down" }), { status: 500 }),
       }),
     } as any;
 

--- a/services/cf-bot/src/lib/__tests__/user-utils.test.ts
+++ b/services/cf-bot/src/lib/__tests__/user-utils.test.ts
@@ -251,9 +251,7 @@ describe("ensureUserExists", () => {
     expect(result!.created).toBe(true);
     expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
     expect(consoleErrorSpy).toHaveBeenCalledWith(
-      expect.stringContaining(
-        "Failed to fetch existing user, will try create",
-      ),
+      expect.stringContaining("Failed to fetch existing user, will try create"),
     );
   });
 

--- a/services/cf-bot/src/lib/__tests__/user-utils.test.ts
+++ b/services/cf-bot/src/lib/__tests__/user-utils.test.ts
@@ -1,8 +1,37 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   getProfileCompleteness,
   getMissingFieldsDisplay,
+  ensureUserExists,
 } from "../user-utils.js";
+import type { MyContext } from "../../types.js";
+
+function mockCtx(overrides: Partial<MyContext> = {}): MyContext {
+  return {
+    from: { id: 123, first_name: "Test", username: "testuser" },
+    reply: vi.fn().mockResolvedValue(undefined),
+    answerCallbackQuery: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as MyContext;
+}
+
+function createMockApiService(responseMap: Record<string, () => Response>) {
+  return {
+    fetch: vi.fn().mockImplementation((req: Request) => {
+      const url =
+        typeof req === "string" ? req : (req as any).url || String(req);
+      const sortedPatterns = Object.entries(responseMap).sort(
+        (a, b) => b[0].length - a[0].length,
+      );
+      for (const [pattern, factory] of sortedPatterns) {
+        if (url.includes(pattern)) {
+          return Promise.resolve(factory());
+        }
+      }
+      return Promise.resolve(new Response(JSON.stringify({}), { status: 404 }));
+    }),
+  };
+}
 
 describe("getProfileCompleteness", () => {
   it("returns complete for fully filled profile", () => {
@@ -131,5 +160,114 @@ describe("getMissingFieldsDisplay", () => {
   it("returns empty string for no missing fields", () => {
     const result = getMissingFieldsDisplay([]);
     expect(result).toBe("");
+  });
+});
+
+describe("ensureUserExists", () => {
+  const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+  beforeEach(() => {
+    consoleErrorSpy.mockClear();
+    consoleLogSpy.mockClear();
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockClear();
+    consoleLogSpy.mockClear();
+  });
+
+  it("returns existing user when found", async () => {
+    const ctx = mockCtx();
+    const env = {
+      API_SERVICE: createMockApiService({
+        "/users/123": () =>
+          new Response(JSON.stringify({ user: { id: "123", displayName: "Test" } }), {
+            status: 200,
+          }),
+      }),
+    } as any;
+
+    const result = await ensureUserExists(ctx, env);
+
+    expect(result).not.toBeNull();
+    expect(result!.user.id).toBe("123");
+    expect(result!.created).toBe(false);
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(consoleLogSpy).not.toHaveBeenCalled();
+  });
+
+  it("creates user and logs info when 404 (new user)", async () => {
+    const ctx = mockCtx();
+    const env = {
+      API_SERVICE: createMockApiService({
+        "/users/123": () => new Response(JSON.stringify({ error: "Not found" }), { status: 404 }),
+        "/users": () =>
+          new Response(JSON.stringify({ user: { id: "123", displayName: "Test" } }), {
+            status: 200,
+          }),
+      }),
+    } as any;
+
+    const result = await ensureUserExists(ctx, env);
+
+    expect(result).not.toBeNull();
+    expect(result!.user.id).toBe("123");
+    expect(result!.created).toBe(true);
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(consoleLogSpy).toHaveBeenCalled();
+    const logEntry = JSON.parse(consoleLogSpy.mock.calls[0][0]);
+    expect(logEntry.level).toBe("info");
+    expect(logEntry.message).toBe("User not found, will create");
+  });
+
+  it("logs error for non-404 API failures", async () => {
+    const ctx = mockCtx();
+    const env = {
+      API_SERVICE: createMockApiService({
+        "/users/123": () => new Response(JSON.stringify({ error: "DB down" }), { status: 500 }),
+        "/users": () =>
+          new Response(JSON.stringify({ user: { id: "123", displayName: "Test" } }), {
+            status: 200,
+          }),
+      }),
+    } as any;
+
+    const result = await ensureUserExists(ctx, env);
+
+    // createUser succeeds, so result is not null
+    expect(result).not.toBeNull();
+    expect(result!.created).toBe(true);
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    const logEntry = JSON.parse(consoleErrorSpy.mock.calls[0][0]);
+    expect(logEntry.level).toBe("error");
+    expect(logEntry.message).toBe("Failed to fetch existing user, will try create");
+  });
+
+  it("returns null when both getUser and createUser fail", async () => {
+    const ctx = mockCtx();
+    const env = {
+      API_SERVICE: createMockApiService({
+        "/users/123": () => new Response(JSON.stringify({ error: "DB down" }), { status: 500 }),
+        "/users": () => new Response(JSON.stringify({ error: "DB down" }), { status: 500 }),
+      }),
+    } as any;
+
+    const result = await ensureUserExists(ctx, env);
+
+    expect(result).toBeNull();
+    // One error log from getUser failure, one console.error from createUser failure
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns null when ctx.from is missing", async () => {
+    const ctx = mockCtx({ from: undefined });
+    const env = { API_SERVICE: createMockApiService({}) } as any;
+
+    const result = await ensureUserExists(ctx, env);
+
+    expect(result).toBeNull();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(consoleLogSpy).not.toHaveBeenCalled();
   });
 });

--- a/services/cf-bot/src/lib/user-utils.ts
+++ b/services/cf-bot/src/lib/user-utils.ts
@@ -1,6 +1,6 @@
 import type { MyContext } from "../types.js";
 import type { Env } from "../index.js";
-import { ApiServiceClient } from "../services/api-client.js";
+import { ApiServiceClient, ApiError } from "../services/api-client.js";
 import { createLogger } from "@meetsmatch/cf-shared";
 
 const log = createLogger("cf-bot");
@@ -194,12 +194,17 @@ export async function ensureUserExists(
       return { user: response.user as UserProfile, created: false };
     }
   } catch (error) {
-    log.error(
-      "ensureUserExists",
-      "Failed to fetch existing user, will try create",
-      { userId },
-      error,
-    );
+    if (error instanceof ApiError && error.status === 404) {
+      // Expected for new users — don't log as error
+      log.info("ensureUserExists", "User not found, will create", { userId });
+    } else {
+      log.error(
+        "ensureUserExists",
+        "Failed to fetch existing user, will try create",
+        { userId },
+        error,
+      );
+    }
   }
 
   // Create user if not found


### PR DESCRIPTION
## Problem

Production logs were flooded with error-level entries for every new user:

```
ApiError: API 404 on /users/{userId}
  at ensureUserExists
```

A 404 from `getUser` is **expected behavior** for first-time users — the bot intentionally tries to fetch the user, gets 404, then creates them. Logging this as `error` creates false-positive alerts and makes real issues harder to spot.

## Fix

- **404 ApiError**: logs at `info` level (`User not found, will create`)
- **Non-404 errors**: still logs at `error` level (genuine failures)
- **Other exceptions**: still logs at `error` level

## Tests

Added 5 unit tests for `ensureUserExists`:

| Test | Description |
|------|-------------|
| returns existing user when found | Happy path |
| creates user and logs info when 404 | New user → info log, not error |
| logs error for non-404 API failures | 500 from getUser → error log |
| returns null when both getUser and createUser fail | Complete failure path |
| returns null when ctx.from is missing | Guard clause |

## Verification

- `pnpm lint` ✅
- `pnpm test --run` ✅ (60 files, 851 passed, 5 skipped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling to distinguish between "user not found" scenarios and other failures during user retrieval operations
  * Improved logging to provide appropriate severity levels for different error types

* **Tests**
  * Expanded test coverage for user existence validation with multiple scenario verification

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/irfndi/meets-match/pull/141?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->