### PR TITLE
fix: trust age column over birthDate and apply default gender prefs in API

### DIFF
--- a/packages/cf-shared/src/__tests__/contracts/user.test.ts
+++ b/packages/cf-shared/src/__tests__/contracts/user.test.ts
@@ -137,10 +137,14 @@ describe("User Contracts", () => {
       expect(result.city).toBeUndefined();
     });
 
-    it("should reject location without latitude", () => {
-      expect(() =>
-        Schema.decodeUnknownSync(Location)({ longitude: 0 }),
-      ).toThrow();
+    it("should decode location without latitude (city-only)", () => {
+      const result = Schema.decodeUnknownSync(Location)({
+        longitude: 0,
+        city: "Jakarta",
+        country: "Indonesia",
+      });
+      expect(result.latitude).toBeUndefined();
+      expect(result.city).toBe("Jakarta");
     });
   });
 

--- a/packages/cf-shared/src/__tests__/contracts/user.test.ts
+++ b/packages/cf-shared/src/__tests__/contracts/user.test.ts
@@ -137,14 +137,28 @@ describe("User Contracts", () => {
       expect(result.city).toBeUndefined();
     });
 
-    it("should decode location without latitude (city-only)", () => {
+    it("should decode location without coordinates (city-only)", () => {
       const result = Schema.decodeUnknownSync(Location)({
-        longitude: 0,
         city: "Jakarta",
         country: "Indonesia",
       });
       expect(result.latitude).toBeUndefined();
       expect(result.city).toBe("Jakarta");
+    });
+
+    it("should reject partial coordinates (only latitude or only longitude)", () => {
+      expect(() =>
+        Schema.decodeUnknownSync(Location)({
+          latitude: 0,
+          city: "Jakarta",
+        }),
+      ).toThrow();
+      expect(() =>
+        Schema.decodeUnknownSync(Location)({
+          longitude: 0,
+          city: "Jakarta",
+        }),
+      ).toThrow();
     });
   });
 

--- a/packages/cf-shared/src/__tests__/preferences.test.ts
+++ b/packages/cf-shared/src/__tests__/preferences.test.ts
@@ -7,7 +7,7 @@ import {
 describe("computeAgeFromBirthDate", () => {
   it("computes age from ISO birthDate", () => {
     const birthYear = new Date().getFullYear() - 25;
-    const age = computeAgeFromBirthDate(`${birthYear}-01-15`);
+    const age = computeAgeFromBirthDate(`${birthYear}-01-01`);
     expect(age).toBe(25);
   });
 
@@ -80,7 +80,7 @@ describe("computeDefaultPreferences", () => {
     const birthYear = new Date().getFullYear() - 25;
     const result = computeDefaultPreferences({
       gender: "male",
-      birthDate: `${birthYear}-01-15`,
+      birthDate: `${birthYear}-01-01`,
     });
     expect(result.minAge).toBe(18);
     expect(result.maxAge).toBe(32);

--- a/packages/cf-shared/src/__tests__/preferences.test.ts
+++ b/packages/cf-shared/src/__tests__/preferences.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeDefaultPreferences,
+  computeAgeFromBirthDate,
+} from "../preferences.js";
+
+describe("computeAgeFromBirthDate", () => {
+  it("computes age from ISO birthDate", () => {
+    const birthYear = new Date().getFullYear() - 25;
+    const age = computeAgeFromBirthDate(`${birthYear}-01-15`);
+    expect(age).toBe(25);
+  });
+
+  it("computes age from DD.MM.YYYY birthDate", () => {
+    const birthYear = new Date().getFullYear() - 30;
+    const age = computeAgeFromBirthDate(`15.01.${birthYear}`);
+    expect(age).toBe(30);
+  });
+
+  it("returns undefined for invalid format", () => {
+    expect(computeAgeFromBirthDate("not-a-date")).toBeUndefined();
+  });
+
+  it("returns undefined for out-of-range ages", () => {
+    const tooOld = `${new Date().getFullYear() - 100}-01-01`;
+    expect(computeAgeFromBirthDate(tooOld)).toBeUndefined();
+  });
+});
+
+describe("computeDefaultPreferences", () => {
+  it("returns opposite-sex preference for male users", () => {
+    const result = computeDefaultPreferences({ gender: "male", age: 25 });
+    expect(result.genderPreference).toEqual(["female"]);
+    expect(result.minAge).toBe(18);
+    expect(result.maxAge).toBe(32);
+    expect(result.maxDistance).toBe(25);
+  });
+
+  it("returns opposite-sex preference for female users", () => {
+    const result = computeDefaultPreferences({ gender: "female", age: 30 });
+    expect(result.genderPreference).toEqual(["male"]);
+    expect(result.minAge).toBe(23);
+    expect(result.maxAge).toBe(37);
+  });
+
+  it("returns all-genders for 'other' gender", () => {
+    const result = computeDefaultPreferences({ gender: "other", age: 28 });
+    expect(result.genderPreference).toEqual([
+      "male",
+      "female",
+      "other",
+      "prefer_not_to_say",
+    ]);
+  });
+
+  it("returns all-genders for 'prefer_not_to_say' gender", () => {
+    const result = computeDefaultPreferences({
+      gender: "prefer_not_to_say",
+      age: 28,
+    });
+    expect(result.genderPreference).toEqual([
+      "male",
+      "female",
+      "other",
+      "prefer_not_to_say",
+    ]);
+  });
+
+  it("clamps age bounds to 12–80", () => {
+    const young = computeDefaultPreferences({ gender: "male", age: 15 });
+    expect(young.minAge).toBe(12);
+    expect(young.maxAge).toBe(22);
+
+    const old = computeDefaultPreferences({ gender: "male", age: 78 });
+    expect(old.minAge).toBe(71);
+    expect(old.maxAge).toBe(80);
+  });
+
+  it("falls back to birthDate when age is missing", () => {
+    const birthYear = new Date().getFullYear() - 25;
+    const result = computeDefaultPreferences({
+      gender: "male",
+      birthDate: `${birthYear}-01-15`,
+    });
+    expect(result.minAge).toBe(18);
+    expect(result.maxAge).toBe(32);
+  });
+
+  it("returns only maxDistance when neither age nor gender is present", () => {
+    const result = computeDefaultPreferences({});
+    expect(result.genderPreference).toBeUndefined();
+    expect(result.minAge).toBeUndefined();
+    expect(result.maxAge).toBeUndefined();
+    expect(result.maxDistance).toBe(25);
+  });
+});

--- a/packages/cf-shared/src/contracts/user.ts
+++ b/packages/cf-shared/src/contracts/user.ts
@@ -16,10 +16,11 @@ export type Gender = typeof Gender.Type;
 // --- Nested Types ---
 
 export const Location = Struct({
-  latitude: Number,
-  longitude: Number,
+  latitude: optional(Number),
+  longitude: optional(Number),
   city: optional(String),
   country: optional(String),
+  source: optional(Literal("gps", "geocoded")),
   lastUpdated: optional(String), // ISO 8601
 });
 export type Location = typeof Location.Type;

--- a/packages/cf-shared/src/contracts/user.ts
+++ b/packages/cf-shared/src/contracts/user.ts
@@ -5,6 +5,7 @@ import {
   Number,
   String,
   Struct,
+  filter,
   optional,
 } from "effect/Schema";
 
@@ -22,7 +23,13 @@ export const Location = Struct({
   country: optional(String),
   source: optional(Literal("gps", "geocoded")),
   lastUpdated: optional(String), // ISO 8601
-});
+}).pipe(
+  filter((loc) => {
+    const hasLat = loc.latitude != null;
+    const hasLon = loc.longitude != null;
+    return hasLat === hasLon;
+  }),
+);
 export type Location = typeof Location.Type;
 
 export const SubscriptionTier = Literal("free", "premium", "premium_plus");

--- a/packages/cf-shared/src/index.ts
+++ b/packages/cf-shared/src/index.ts
@@ -7,3 +7,4 @@ export * from "./errors.js";
 export * from "./structured-log.js";
 export * from "./version.js";
 export * from "./media.js";
+export * from "./preferences.js";

--- a/packages/cf-shared/src/preferences.ts
+++ b/packages/cf-shared/src/preferences.ts
@@ -43,6 +43,17 @@ export function computeAgeFromBirthDate(birthDate: string): number | undefined {
     const year = parseInt(isoMatch[1], 10);
     const month = parseInt(isoMatch[2], 10);
     const day = parseInt(isoMatch[3], 10);
+
+    // Validate actual calendar date
+    const date = new Date(year, month - 1, day);
+    if (
+      date.getFullYear() !== year ||
+      date.getMonth() !== month - 1 ||
+      date.getDate() !== day
+    ) {
+      return undefined;
+    }
+
     const now = new Date();
     let age = now.getFullYear() - year;
     const m = now.getMonth() - (month - 1);
@@ -78,8 +89,9 @@ export function computeDefaultPreferences(
         : (["male", "female", "other", "prefer_not_to_say"] as const)
     : undefined;
 
-  const minAge = age != null ? Math.max(12, age - 7) : undefined;
-  const maxAge = age != null ? Math.min(80, age + 7) : undefined;
+  const normalizedAge = age != null ? Math.max(12, Math.min(80, age)) : undefined;
+  const minAge = normalizedAge != null ? Math.max(12, normalizedAge - 7) : undefined;
+  const maxAge = normalizedAge != null ? Math.min(80, normalizedAge + 7) : undefined;
   const maxDistance = 25;
 
   const defaults: Record<string, unknown> = {};

--- a/packages/cf-shared/src/preferences.ts
+++ b/packages/cf-shared/src/preferences.ts
@@ -89,9 +89,12 @@ export function computeDefaultPreferences(
         : (["male", "female", "other", "prefer_not_to_say"] as const)
     : undefined;
 
-  const normalizedAge = age != null ? Math.max(12, Math.min(80, age)) : undefined;
-  const minAge = normalizedAge != null ? Math.max(12, normalizedAge - 7) : undefined;
-  const maxAge = normalizedAge != null ? Math.min(80, normalizedAge + 7) : undefined;
+  const normalizedAge =
+    age != null ? Math.max(12, Math.min(80, age)) : undefined;
+  const minAge =
+    normalizedAge != null ? Math.max(12, normalizedAge - 7) : undefined;
+  const maxAge =
+    normalizedAge != null ? Math.min(80, normalizedAge + 7) : undefined;
   const maxDistance = 25;
 
   const defaults: Record<string, unknown> = {};

--- a/packages/cf-shared/src/preferences.ts
+++ b/packages/cf-shared/src/preferences.ts
@@ -1,0 +1,92 @@
+import type { Preferences } from "./contracts/user.js";
+
+export interface DefaultPreferenceInput {
+  age?: number;
+  birthDate?: string;
+  gender?: string;
+}
+
+const BIRTHDATE_REGEX = /^(0[1-9]|[12]\d|3[01])\.(0[1-9]|1[0-2])\.(\d{4})$/;
+
+function parseBirthDate(
+  input: string,
+): { day: number; month: number; year: number } | null {
+  const match = input.trim().match(BIRTHDATE_REGEX);
+  if (!match) return null;
+  const day = parseInt(match[1], 10);
+  const month = parseInt(match[2], 10);
+  const year = parseInt(match[3], 10);
+
+  const date = new Date(year, month - 1, day);
+  if (
+    date.getFullYear() !== year ||
+    date.getMonth() !== month - 1 ||
+    date.getDate() !== day
+  ) {
+    return null;
+  }
+
+  const now = new Date();
+  let age = now.getFullYear() - year;
+  const m = now.getMonth() - (month - 1);
+  if (m < 0 || (m === 0 && now.getDate() < day)) {
+    age--;
+  }
+  if (age < 12 || age > 80) return null;
+
+  return { day, month, year };
+}
+
+export function computeAgeFromBirthDate(birthDate: string): number | undefined {
+  const isoMatch = birthDate.trim().match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (isoMatch) {
+    const year = parseInt(isoMatch[1], 10);
+    const month = parseInt(isoMatch[2], 10);
+    const day = parseInt(isoMatch[3], 10);
+    const now = new Date();
+    let age = now.getFullYear() - year;
+    const m = now.getMonth() - (month - 1);
+    if (m < 0 || (m === 0 && now.getDate() < day)) {
+      age--;
+    }
+    if (age >= 12 && age <= 80) return age;
+  }
+
+  const parsed = parseBirthDate(birthDate);
+  if (!parsed) return undefined;
+  const now = new Date();
+  let age = now.getFullYear() - parsed.year;
+  const m = now.getMonth() - (parsed.month - 1);
+  if (m < 0 || (m === 0 && now.getDate() < parsed.day)) {
+    age--;
+  }
+  return age;
+}
+
+export function computeDefaultPreferences(
+  input: DefaultPreferenceInput,
+): Partial<Preferences> {
+  const age =
+    input.age ??
+    (input.birthDate ? computeAgeFromBirthDate(input.birthDate) : undefined);
+
+  const genderPreference = input.gender
+    ? input.gender === "male"
+      ? (["female"] as const)
+      : input.gender === "female"
+        ? (["male"] as const)
+        : (["male", "female", "other", "prefer_not_to_say"] as const)
+    : undefined;
+
+  const minAge = age != null ? Math.max(12, age - 7) : undefined;
+  const maxAge = age != null ? Math.min(80, age + 7) : undefined;
+  const maxDistance = 25;
+
+  const defaults: Record<string, unknown> = {};
+  if (genderPreference) defaults.genderPreference = genderPreference;
+  if (minAge != null) defaults.minAge = minAge;
+  if (maxAge != null) defaults.maxAge = maxAge;
+  defaults.maxDistance = maxDistance;
+
+  return defaults as Partial<Preferences>;
+}

--- a/services/cf-api/src/models/__tests__/match.test.ts
+++ b/services/cf-api/src/models/__tests__/match.test.ts
@@ -534,6 +534,40 @@ describe("MatchRepository.getPotentialMatches JS filtering", () => {
     expect(result[0].id).toBe("2");
   });
 
+  it("does not hard-filter geocoded users by distance", async () => {
+    const currentUser = createDbRow({
+      id: "1",
+      location: JSON.stringify({
+        latitude: 0,
+        longitude: 0,
+        source: "geocoded",
+      }),
+      preferences: JSON.stringify({ maxDistance: 10 }),
+    });
+    const candidates = [
+      createDbRow({
+        id: "2",
+        location: JSON.stringify({
+          latitude: 0,
+          longitude: 100,
+          source: "geocoded",
+        }),
+        first_name: "FarGeocoded",
+        preferences: "{}",
+      }),
+    ];
+
+    const mockD1 = createMockD1(candidates, currentUser);
+    const userRepo = new UserRepository(mockD1);
+    const matchRepo = new MatchRepository(mockD1, userRepo);
+
+    const result = await Effect.runPromise(
+      matchRepo.getPotentialMatches({ userId: "1", limit: 10 }),
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("2");
+  });
+
   it("respects cooldown for disliked profiles", async () => {
     const now = new Date().toISOString();
     const currentUser = createDbRow({ id: "1", preferences: "{}" });
@@ -977,7 +1011,7 @@ describe("computeDefaultPreferences", () => {
 
   it("falls back to birthDate when age is missing", () => {
     const birthYear = new Date().getFullYear() - 25;
-    const birthDate = `${birthYear}-01-15`;
+    const birthDate = `${birthYear}-01-01`;
     const result = computeDefaultPreferences({
       gender: "male",
       birthDate,

--- a/services/cf-api/src/models/__tests__/match.test.ts
+++ b/services/cf-api/src/models/__tests__/match.test.ts
@@ -1,10 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { Effect } from "effect";
-import {
-  MatchRepository,
-  calculateMatchScore,
-  haversine,
-} from "../match.js";
+import { MatchRepository, calculateMatchScore, haversine } from "../match.js";
 import { UserRepository } from "../user.js";
 import { computeDefaultPreferences } from "@meetsmatch/cf-shared";
 

--- a/services/cf-api/src/models/__tests__/match.test.ts
+++ b/services/cf-api/src/models/__tests__/match.test.ts
@@ -205,6 +205,28 @@ describe("calculateMatchScore", () => {
     expect(score.preferences).toBe(0);
     expect(score.total).toBeCloseTo(0.5, 5);
   });
+
+  it("gives 0 location score when both users have geocoded coordinates", () => {
+    const user1 = createUser({
+      location: { latitude: -6.2, longitude: 106.8, source: "geocoded" },
+    });
+    const user2 = createUser({
+      location: { latitude: -6.2, longitude: 106.8, source: "geocoded" },
+    });
+    const score = calculateMatchScore(user1 as any, user2 as any);
+    expect(score.location).toBe(0);
+  });
+
+  it("gives 0 location score when one user has geocoded coordinates", () => {
+    const user1 = createUser({
+      location: { latitude: 0, longitude: 0, source: "gps" },
+    });
+    const user2 = createUser({
+      location: { latitude: -6.2, longitude: 106.8, source: "geocoded" },
+    });
+    const score = calculateMatchScore(user1 as any, user2 as any);
+    expect(score.location).toBe(0);
+  });
 });
 
 describe("MatchRepository.getPotentialMatches SQL", () => {

--- a/services/cf-api/src/models/__tests__/match.test.ts
+++ b/services/cf-api/src/models/__tests__/match.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi } from "vitest";
 import { Effect } from "effect";
-import { MatchRepository, calculateMatchScore, haversine } from "../match.js";
+import {
+  MatchRepository,
+  calculateMatchScore,
+  haversine,
+  computeDefaultPreferences,
+} from "../match.js";
 import { UserRepository } from "../user.js";
 
 function createMockD1(
@@ -338,6 +343,34 @@ describe("MatchRepository.getPotentialMatches SQL", () => {
     const currentUser = createDbRow({
       id: "1",
       gender: "other",
+      age: 28,
+      preferences: "{}",
+    });
+    const mockD1 = createMockD1([], currentUser);
+    const userRepo = new UserRepository(mockD1);
+    const matchRepo = new MatchRepository(mockD1, userRepo);
+
+    await Effect.runPromise(
+      matchRepo.getPotentialMatches({ userId: "1", limit: 10 }),
+    );
+
+    const sql = mockD1._capturedSql.find((s) => s.includes("FROM users u"));
+    expect(sql).toContain("u.gender IN (?,?,?,?)");
+
+    const values = mockD1._capturedValues.find((v) =>
+      v.some((x) => x === "male"),
+    );
+    expect(values).toBeDefined();
+    expect(values).toContain("male");
+    expect(values).toContain("female");
+    expect(values).toContain("other");
+    expect(values).toContain("prefer_not_to_say");
+  });
+
+  it("applies all-genders default for 'prefer_not_to_say' gender with empty prefs", async () => {
+    const currentUser = createDbRow({
+      id: "1",
+      gender: "prefer_not_to_say",
       age: 28,
       preferences: "{}",
     });
@@ -781,5 +814,97 @@ describe("MatchRepository.getPendingLikes", () => {
     const sql = mockD1._capturedSql.find((s) => s.includes("FROM matches m"));
     expect(sql).toContain("blocks");
     expect(sql).toContain("NOT EXISTS");
+  });
+});
+
+describe("computeDefaultPreferences", () => {
+  it("returns opposite-sex preference for male users", () => {
+    const result = computeDefaultPreferences({
+      id: "1",
+      gender: "male",
+      age: 25,
+    } as any);
+    expect(result.genderPreference).toEqual(["female"]);
+    expect(result.minAge).toBe(18);
+    expect(result.maxAge).toBe(32);
+    expect(result.maxDistance).toBe(25);
+  });
+
+  it("returns opposite-sex preference for female users", () => {
+    const result = computeDefaultPreferences({
+      id: "1",
+      gender: "female",
+      age: 30,
+    } as any);
+    expect(result.genderPreference).toEqual(["male"]);
+    expect(result.minAge).toBe(23);
+    expect(result.maxAge).toBe(37);
+  });
+
+  it("returns all-genders preference for 'other' gender", () => {
+    const result = computeDefaultPreferences({
+      id: "1",
+      gender: "other",
+      age: 28,
+    } as any);
+    expect(result.genderPreference).toEqual([
+      "male",
+      "female",
+      "other",
+      "prefer_not_to_say",
+    ]);
+  });
+
+  it("returns all-genders preference for 'prefer_not_to_say' gender", () => {
+    const result = computeDefaultPreferences({
+      id: "1",
+      gender: "prefer_not_to_say",
+      age: 28,
+    } as any);
+    expect(result.genderPreference).toEqual([
+      "male",
+      "female",
+      "other",
+      "prefer_not_to_say",
+    ]);
+  });
+
+  it("clamps minAge to 12 and maxAge to 80", () => {
+    const result = computeDefaultPreferences({
+      id: "1",
+      gender: "male",
+      age: 15,
+    } as any);
+    expect(result.minAge).toBe(12); // 15-7=8, clamped to 12
+    expect(result.maxAge).toBe(22); // 15+7=22
+
+    const resultOld = computeDefaultPreferences({
+      id: "1",
+      gender: "male",
+      age: 78,
+    } as any);
+    expect(resultOld.minAge).toBe(71); // 78-7=71
+    expect(resultOld.maxAge).toBe(80); // 78+7=85, clamped to 80
+  });
+
+  it("handles missing age gracefully", () => {
+    const result = computeDefaultPreferences({
+      id: "1",
+      gender: "male",
+    } as any);
+    expect(result.genderPreference).toEqual(["female"]);
+    expect(result.minAge).toBeUndefined();
+    expect(result.maxAge).toBeUndefined();
+    expect(result.maxDistance).toBe(25);
+  });
+
+  it("handles missing gender gracefully", () => {
+    const result = computeDefaultPreferences({
+      id: "1",
+      age: 25,
+    } as any);
+    expect(result.genderPreference).toBeUndefined();
+    expect(result.minAge).toBe(18);
+    expect(result.maxAge).toBe(32);
   });
 });

--- a/services/cf-api/src/models/__tests__/match.test.ts
+++ b/services/cf-api/src/models/__tests__/match.test.ts
@@ -4,9 +4,9 @@ import {
   MatchRepository,
   calculateMatchScore,
   haversine,
-  computeDefaultPreferences,
 } from "../match.js";
 import { UserRepository } from "../user.js";
+import { computeDefaultPreferences } from "@meetsmatch/cf-shared";
 
 function createMockD1(
   candidates: Array<Record<string, unknown>> = [],
@@ -446,6 +446,63 @@ describe("MatchRepository.getPotentialMatches SQL", () => {
     expect(values).toContain(20);
     expect(values).toContain(40);
   });
+
+  it("applies gender default when stored preference array is empty", async () => {
+    const currentUser = createDbRow({
+      id: "1",
+      gender: "male",
+      age: 25,
+      preferences: JSON.stringify({
+        genderPreference: [],
+      }),
+    });
+    const mockD1 = createMockD1([], currentUser);
+    const userRepo = new UserRepository(mockD1);
+    const matchRepo = new MatchRepository(mockD1, userRepo);
+
+    await Effect.runPromise(
+      matchRepo.getPotentialMatches({ userId: "1", limit: 10 }),
+    );
+
+    const sql = mockD1._capturedSql.find((s) => s.includes("FROM users u"));
+    expect(sql).toContain("u.gender IN (?)");
+
+    const values = mockD1._capturedValues.find((v) =>
+      v.some((x) => x === "female"),
+    );
+    expect(values).toBeDefined();
+    expect(values).toContain("female");
+  });
+
+  it("preserves existing age prefs and only fills missing gender default", async () => {
+    const currentUser = createDbRow({
+      id: "1",
+      gender: "male",
+      age: 25,
+      preferences: JSON.stringify({
+        minAge: 22,
+        maxAge: 35,
+        maxDistance: 50,
+      }),
+    });
+    const mockD1 = createMockD1([], currentUser);
+    const userRepo = new UserRepository(mockD1);
+    const matchRepo = new MatchRepository(mockD1, userRepo);
+
+    await Effect.runPromise(
+      matchRepo.getPotentialMatches({ userId: "1", limit: 10 }),
+    );
+
+    const values = mockD1._capturedValues.find((v) =>
+      v.some((x) => x === "female"),
+    );
+    expect(values).toBeDefined();
+    expect(values).toContain("female");
+    expect(values).toContain(22);
+    expect(values).toContain(35);
+    expect(values).not.toContain(18);
+    expect(values).not.toContain(32);
+  });
 });
 
 describe("MatchRepository.getPotentialMatches JS filtering", () => {
@@ -842,10 +899,9 @@ describe("MatchRepository.getPendingLikes", () => {
 describe("computeDefaultPreferences", () => {
   it("returns opposite-sex preference for male users", () => {
     const result = computeDefaultPreferences({
-      id: "1",
       gender: "male",
       age: 25,
-    } as any);
+    });
     expect(result.genderPreference).toEqual(["female"]);
     expect(result.minAge).toBe(18);
     expect(result.maxAge).toBe(32);
@@ -854,10 +910,9 @@ describe("computeDefaultPreferences", () => {
 
   it("returns opposite-sex preference for female users", () => {
     const result = computeDefaultPreferences({
-      id: "1",
       gender: "female",
       age: 30,
-    } as any);
+    });
     expect(result.genderPreference).toEqual(["male"]);
     expect(result.minAge).toBe(23);
     expect(result.maxAge).toBe(37);
@@ -865,10 +920,9 @@ describe("computeDefaultPreferences", () => {
 
   it("returns all-genders preference for 'other' gender", () => {
     const result = computeDefaultPreferences({
-      id: "1",
       gender: "other",
       age: 28,
-    } as any);
+    });
     expect(result.genderPreference).toEqual([
       "male",
       "female",
@@ -879,10 +933,9 @@ describe("computeDefaultPreferences", () => {
 
   it("returns all-genders preference for 'prefer_not_to_say' gender", () => {
     const result = computeDefaultPreferences({
-      id: "1",
       gender: "prefer_not_to_say",
       age: 28,
-    } as any);
+    });
     expect(result.genderPreference).toEqual([
       "male",
       "female",
@@ -893,27 +946,24 @@ describe("computeDefaultPreferences", () => {
 
   it("clamps minAge to 12 and maxAge to 80", () => {
     const result = computeDefaultPreferences({
-      id: "1",
       gender: "male",
       age: 15,
-    } as any);
+    });
     expect(result.minAge).toBe(12); // 15-7=8, clamped to 12
     expect(result.maxAge).toBe(22); // 15+7=22
 
     const resultOld = computeDefaultPreferences({
-      id: "1",
       gender: "male",
       age: 78,
-    } as any);
+    });
     expect(resultOld.minAge).toBe(71); // 78-7=71
     expect(resultOld.maxAge).toBe(80); // 78+7=85, clamped to 80
   });
 
   it("handles missing age gracefully", () => {
     const result = computeDefaultPreferences({
-      id: "1",
       gender: "male",
-    } as any);
+    });
     expect(result.genderPreference).toEqual(["female"]);
     expect(result.minAge).toBeUndefined();
     expect(result.maxAge).toBeUndefined();
@@ -922,10 +972,20 @@ describe("computeDefaultPreferences", () => {
 
   it("handles missing gender gracefully", () => {
     const result = computeDefaultPreferences({
-      id: "1",
       age: 25,
-    } as any);
+    });
     expect(result.genderPreference).toBeUndefined();
+    expect(result.minAge).toBe(18);
+    expect(result.maxAge).toBe(32);
+  });
+
+  it("falls back to birthDate when age is missing", () => {
+    const birthYear = new Date().getFullYear() - 25;
+    const birthDate = `${birthYear}-01-15`;
+    const result = computeDefaultPreferences({
+      gender: "male",
+      birthDate,
+    });
     expect(result.minAge).toBe(18);
     expect(result.maxAge).toBe(32);
   });

--- a/services/cf-api/src/models/__tests__/match.test.ts
+++ b/services/cf-api/src/models/__tests__/match.test.ts
@@ -283,6 +283,114 @@ describe("MatchRepository.getPotentialMatches SQL", () => {
     expect(values).toContain(17);
     expect(values).toContain(33);
   });
+
+  it("applies default gender preference when user has empty preferences", async () => {
+    const currentUser = createDbRow({
+      id: "1",
+      gender: "male",
+      age: 25,
+      preferences: "{}",
+    });
+    const mockD1 = createMockD1([], currentUser);
+    const userRepo = new UserRepository(mockD1);
+    const matchRepo = new MatchRepository(mockD1, userRepo);
+
+    await Effect.runPromise(
+      matchRepo.getPotentialMatches({ userId: "1", limit: 10 }),
+    );
+
+    const sql = mockD1._capturedSql.find((s) => s.includes("FROM users u"));
+    expect(sql).toContain("u.gender IN (?)");
+
+    const values = mockD1._capturedValues.find((v) =>
+      v.some((x) => x === "female"),
+    );
+    expect(values).toBeDefined();
+    expect(values).toContain("female");
+    // Default age range: 25-7=18, 25+7=32
+    expect(values).toContain(18);
+    expect(values).toContain(32);
+  });
+
+  it("applies default opposite-sex preference for female users", async () => {
+    const currentUser = createDbRow({
+      id: "1",
+      gender: "female",
+      age: 30,
+      preferences: "{}",
+    });
+    const mockD1 = createMockD1([], currentUser);
+    const userRepo = new UserRepository(mockD1);
+    const matchRepo = new MatchRepository(mockD1, userRepo);
+
+    await Effect.runPromise(
+      matchRepo.getPotentialMatches({ userId: "1", limit: 10 }),
+    );
+
+    const values = mockD1._capturedValues.find((v) =>
+      v.some((x) => x === "male"),
+    );
+    expect(values).toBeDefined();
+    expect(values).toContain("male");
+  });
+
+  it("applies all-genders default for 'other' gender with empty prefs", async () => {
+    const currentUser = createDbRow({
+      id: "1",
+      gender: "other",
+      age: 28,
+      preferences: "{}",
+    });
+    const mockD1 = createMockD1([], currentUser);
+    const userRepo = new UserRepository(mockD1);
+    const matchRepo = new MatchRepository(mockD1, userRepo);
+
+    await Effect.runPromise(
+      matchRepo.getPotentialMatches({ userId: "1", limit: 10 }),
+    );
+
+    const sql = mockD1._capturedSql.find((s) => s.includes("FROM users u"));
+    expect(sql).toContain("u.gender IN (?,?,?,?)");
+
+    const values = mockD1._capturedValues.find((v) =>
+      v.some((x) => x === "male"),
+    );
+    expect(values).toBeDefined();
+    expect(values).toContain("male");
+    expect(values).toContain("female");
+    expect(values).toContain("other");
+    expect(values).toContain("prefer_not_to_say");
+  });
+
+  it("does not override existing gender preference with defaults", async () => {
+    const currentUser = createDbRow({
+      id: "1",
+      gender: "male",
+      age: 25,
+      preferences: JSON.stringify({
+        genderPreference: ["male", "other"],
+        minAge: 20,
+        maxAge: 40,
+      }),
+    });
+    const mockD1 = createMockD1([], currentUser);
+    const userRepo = new UserRepository(mockD1);
+    const matchRepo = new MatchRepository(mockD1, userRepo);
+
+    await Effect.runPromise(
+      matchRepo.getPotentialMatches({ userId: "1", limit: 10 }),
+    );
+
+    const values = mockD1._capturedValues.find((v) =>
+      v.some((x) => x === "male"),
+    );
+    expect(values).toBeDefined();
+    expect(values).toContain("male");
+    expect(values).toContain("other");
+    expect(values).not.toContain("female");
+    expect(values).toContain(20);
+    expect(values).toContain(40);
+  });
 });
 
 describe("MatchRepository.getPotentialMatches JS filtering", () => {

--- a/services/cf-api/src/models/match.ts
+++ b/services/cf-api/src/models/match.ts
@@ -545,11 +545,14 @@ export class MatchRepository {
                 }
               }
               // Distance from candidate's perspective
+              // Skip when either user has geocoded (imprecise) coordinates.
               if (
                 candidate.location?.latitude != null &&
                 candidate.location?.longitude != null &&
                 currentUser.location?.latitude != null &&
                 currentUser.location?.longitude != null &&
+                candidate.location.source !== "geocoded" &&
+                currentUser.location.source !== "geocoded" &&
                 candidatePrefs?.maxDistance
               ) {
                 const dist = haversine(
@@ -563,11 +566,14 @@ export class MatchRepository {
             }
 
             // --- Current user's distance hard constraint ---
+            // Skip when either user has geocoded (imprecise) coordinates.
             if (
               currentUser.location?.latitude != null &&
               currentUser.location?.longitude != null &&
               candidate.location?.latitude != null &&
               candidate.location?.longitude != null &&
+              currentUser.location.source !== "geocoded" &&
+              candidate.location.source !== "geocoded" &&
               prefs?.maxDistance
             ) {
               const dist = haversine(

--- a/services/cf-api/src/models/match.ts
+++ b/services/cf-api/src/models/match.ts
@@ -21,6 +21,30 @@ import {
 import { UserRepository } from "./user.js";
 import { BlockRepository } from "./block.js";
 
+export function computeDefaultPreferences(
+  currentUser: typeof User.Type,
+): Record<string, unknown> {
+  const defaults: Record<string, unknown> = {};
+
+  if (currentUser.gender) {
+    const gender = currentUser.gender;
+    defaults.genderPreference =
+      gender === "male"
+        ? ["female"]
+        : gender === "female"
+          ? ["male"]
+          : ["male", "female", "other", "prefer_not_to_say"];
+  }
+
+  if (currentUser.age != null) {
+    defaults.minAge = Math.max(12, currentUser.age - 7);
+    defaults.maxAge = Math.min(80, currentUser.age + 7);
+  }
+
+  defaults.maxDistance = 25;
+  return defaults;
+}
+
 export class MatchRepository {
   constructor(
     private readonly db: D1Database,
@@ -366,23 +390,7 @@ export class MatchRepository {
           Array.isArray(prefs.genderPreference) &&
           prefs.genderPreference.length > 0;
         if (!hasGenderPref && currentUser.gender) {
-          const gender = currentUser.gender;
-          const defaultGenderPref =
-            gender === "male"
-              ? ["female"]
-              : gender === "female"
-                ? ["male"]
-                : ["male", "female", "other", "prefer_not_to_say"];
-          const defaults: Record<string, unknown> = {
-            genderPreference: defaultGenderPref,
-          };
-          if (currentUser.age != null) {
-            defaults.minAge = Math.max(12, currentUser.age - 7);
-            defaults.maxAge = Math.min(80, currentUser.age + 7);
-          }
-          if (prefs.maxDistance == null) {
-            defaults.maxDistance = 25;
-          }
+          const defaults = computeDefaultPreferences(currentUser);
           prefs = { ...defaults, ...prefs };
         }
 

--- a/services/cf-api/src/models/match.ts
+++ b/services/cf-api/src/models/match.ts
@@ -862,7 +862,18 @@ export function calculateMatchScore(
   };
 
   // 1. Location Score
-  if (user1.location && user2.location) {
+  // Skip scoring when either user has geocoded city-center coordinates,
+  // which are imprecise and would give misleading scores.
+  // Old data without a source field is treated as potentially GPS for
+  // backward compatibility.
+  if (
+    user1.location?.latitude != null &&
+    user1.location?.longitude != null &&
+    user2.location?.latitude != null &&
+    user2.location?.longitude != null &&
+    user1.location.source !== "geocoded" &&
+    user2.location.source !== "geocoded"
+  ) {
     const dist = haversine(
       user1.location.latitude,
       user1.location.longitude,

--- a/services/cf-api/src/models/match.ts
+++ b/services/cf-api/src/models/match.ts
@@ -5,6 +5,7 @@ import {
   MatchStatus,
   MatchAction,
   User,
+  type Preferences,
   type CreateMatchRequest,
   type GetMatchRequest,
   type GetMatchListRequest,
@@ -17,33 +18,10 @@ import {
   NotFoundError,
   DatabaseError,
   ValidationError,
+  computeDefaultPreferences,
 } from "@meetsmatch/cf-shared";
 import { UserRepository } from "./user.js";
 import { BlockRepository } from "./block.js";
-
-export function computeDefaultPreferences(
-  currentUser: typeof User.Type,
-): Record<string, unknown> {
-  const defaults: Record<string, unknown> = {};
-
-  if (currentUser.gender) {
-    const gender = currentUser.gender;
-    defaults.genderPreference =
-      gender === "male"
-        ? ["female"]
-        : gender === "female"
-          ? ["male"]
-          : ["male", "female", "other", "prefer_not_to_say"];
-  }
-
-  if (currentUser.age != null) {
-    defaults.minAge = Math.max(12, currentUser.age - 7);
-    defaults.maxAge = Math.min(80, currentUser.age + 7);
-  }
-
-  defaults.maxDistance = 25;
-  return defaults;
-}
 
 export class MatchRepository {
   constructor(
@@ -381,7 +359,7 @@ export class MatchRepository {
           return [];
         }
 
-        let prefs = currentUser.preferences ?? {};
+        let prefs: Preferences = currentUser.preferences ?? {};
 
         // Compute default preferences for new users who haven't set any.
         // This ensures gender filtering is always applied even if the bot-side
@@ -390,8 +368,25 @@ export class MatchRepository {
           Array.isArray(prefs.genderPreference) &&
           prefs.genderPreference.length > 0;
         if (!hasGenderPref && currentUser.gender) {
-          const defaults = computeDefaultPreferences(currentUser);
-          prefs = { ...defaults, ...prefs };
+          const defaults = computeDefaultPreferences({
+            age: currentUser.age ?? undefined,
+            birthDate: currentUser.birthDate ?? undefined,
+            gender: currentUser.gender,
+          });
+          // Apply defaults field-by-field to preserve type safety and avoid
+          // overwriting existing non-empty preference values.
+          if (defaults.genderPreference != null) {
+            prefs = { ...prefs, genderPreference: defaults.genderPreference };
+          }
+          if (prefs.minAge == null && defaults.minAge != null) {
+            prefs = { ...prefs, minAge: defaults.minAge };
+          }
+          if (prefs.maxAge == null && defaults.maxAge != null) {
+            prefs = { ...prefs, maxAge: defaults.maxAge };
+          }
+          if (prefs.maxDistance == null && defaults.maxDistance != null) {
+            prefs = { ...prefs, maxDistance: defaults.maxDistance };
+          }
         }
 
         // 2. Build query for candidates including interacted profiles for cooldown/re-engagement

--- a/services/cf-api/src/models/match.ts
+++ b/services/cf-api/src/models/match.ts
@@ -357,7 +357,34 @@ export class MatchRepository {
           return [];
         }
 
-        const prefs = currentUser.preferences;
+        let prefs = currentUser.preferences ?? {};
+
+        // Compute default preferences for new users who haven't set any.
+        // This ensures gender filtering is always applied even if the bot-side
+        // default-preference save failed or hasn't run yet.
+        const hasGenderPref =
+          Array.isArray(prefs.genderPreference) &&
+          prefs.genderPreference.length > 0;
+        if (!hasGenderPref && currentUser.gender) {
+          const gender = currentUser.gender;
+          const defaultGenderPref =
+            gender === "male"
+              ? ["female"]
+              : gender === "female"
+                ? ["male"]
+                : ["male", "female", "other", "prefer_not_to_say"];
+          const defaults: Record<string, unknown> = {
+            genderPreference: defaultGenderPref,
+          };
+          if (currentUser.age != null) {
+            defaults.minAge = Math.max(12, currentUser.age - 7);
+            defaults.maxAge = Math.min(80, currentUser.age + 7);
+          }
+          if (prefs.maxDistance == null) {
+            defaults.maxDistance = 25;
+          }
+          prefs = { ...defaults, ...prefs };
+        }
 
         // 2. Build query for candidates including interacted profiles for cooldown/re-engagement
         // We fetch more candidates to allow filtering and variety

--- a/services/cf-bot/src/handlers/__tests__/match.test.ts
+++ b/services/cf-bot/src/handlers/__tests__/match.test.ts
@@ -508,5 +508,32 @@ describe("Match Handlers", () => {
         expect.anything(),
       );
     });
+
+    it("still proceeds to find matches when default preference PUT fails", async () => {
+      const consoleErrorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      env.API_SERVICE = createMockApiService({
+        "/users/123": () =>
+          new Response(JSON.stringify({ user: completeUser }), { status: 200 }),
+        "PUT:/users/123": () =>
+          new Response(JSON.stringify({ error: "DB error" }), { status: 500 }),
+        "/potential-matches": () =>
+          new Response(JSON.stringify({ potentialMatches: [] }), {
+            status: 200,
+          }),
+      });
+      await matchCommand(ctx, env);
+      // Should still show "finding" and then "no matches"
+      expect(ctx.reply).toHaveBeenCalledWith(
+        expect.stringContaining("Finding"),
+        expect.anything(),
+      );
+      expect(ctx.reply).toHaveBeenCalledWith(
+        expect.stringContaining("No potential matches found"),
+        expect.anything(),
+      );
+      consoleErrorSpy.mockRestore();
+    });
   });
 });

--- a/services/cf-bot/src/handlers/__tests__/match.test.ts
+++ b/services/cf-bot/src/handlers/__tests__/match.test.ts
@@ -32,11 +32,13 @@ function mockCtx(): MyContext {
 }
 
 function createMockApiService(responseMap: Record<string, () => Response>) {
+  const requests: Array<{ url: string; method: string }> = [];
   return {
     fetch: vi.fn().mockImplementation((req: Request) => {
       const url =
         typeof req === "string" ? req : (req as any).url || String(req);
       const method = (req as any).method || "GET";
+      requests.push({ url, method });
       const sortedPatterns = Object.entries(responseMap).sort(
         (a, b) => b[0].length - a[0].length,
       );
@@ -55,6 +57,7 @@ function createMockApiService(responseMap: Record<string, () => Response>) {
       }
       return Promise.resolve(new Response(JSON.stringify({}), { status: 404 }));
     }),
+    _requests: requests,
   };
 }
 

--- a/services/cf-bot/src/handlers/__tests__/match.test.ts
+++ b/services/cf-bot/src/handlers/__tests__/match.test.ts
@@ -36,11 +36,22 @@ function createMockApiService(responseMap: Record<string, () => Response>) {
     fetch: vi.fn().mockImplementation((req: Request) => {
       const url =
         typeof req === "string" ? req : (req as any).url || String(req);
+      const method = (req as any).method || "GET";
       const sortedPatterns = Object.entries(responseMap).sort(
         (a, b) => b[0].length - a[0].length,
       );
       for (const [pattern, factory] of sortedPatterns) {
-        if (url.includes(pattern)) return Promise.resolve(factory());
+        if (pattern.includes(":")) {
+          // Method-specific pattern: e.g. "PUT:/users/123"
+          const colonIdx = pattern.indexOf(":");
+          const patternMethod = pattern.slice(0, colonIdx);
+          const patternUrl = pattern.slice(colonIdx + 1);
+          if (method === patternMethod && url.includes(patternUrl)) {
+            return Promise.resolve(factory());
+          }
+        } else if (url.includes(pattern)) {
+          return Promise.resolve(factory());
+        }
       }
       return Promise.resolve(new Response(JSON.stringify({}), { status: 404 }));
     }),

--- a/services/cf-bot/src/handlers/__tests__/profile.test.ts
+++ b/services/cf-bot/src/handlers/__tests__/profile.test.ts
@@ -143,4 +143,30 @@ describe("profile handler", () => {
     await profileCommand(ctx, env);
     expect(ctx.reply).toHaveBeenCalled();
   });
+
+  it("trusts the age column over birthDate when manually updated", async () => {
+    const ctx = createCtx();
+    const env = createEnv({
+      birthDate: "1990-01-01",
+      age: 99,
+    });
+
+    await profileCommand(ctx, env);
+    const call = (ctx.reply as any).mock.calls[0];
+    expect(call[0]).toContain("99");
+    expect(call[0]).not.toContain("35"); // ~age from 1990-01-01
+  });
+
+  it("falls back to birthDate computation when age column is missing", async () => {
+    const ctx = createCtx();
+    const env = createEnv({
+      birthDate: "1990-01-01",
+      age: undefined,
+    });
+
+    await profileCommand(ctx, env);
+    const call = (ctx.reply as any).mock.calls[0];
+    // Age from 1990-01-01 should be present (around 35)
+    expect(call[0]).toMatch(/3[456]/);
+  });
 });

--- a/services/cf-bot/src/handlers/__tests__/settings.test.ts
+++ b/services/cf-bot/src/handlers/__tests__/settings.test.ts
@@ -209,8 +209,8 @@ describe("Settings Handlers", () => {
     });
 
     it("handles partially set preferences", async () => {
-      // Full user with birthDate=1999-03-15 (age ~27), gender=female
-      // getDefaultPreferences computes: minAge=20, maxAge=34, maxDistance=25, genderPref=["male"]
+      // Full user with birthDate=1999-03-15 and age=25, gender=female
+      // getDefaultPreferences now trusts age column first: minAge=18, maxAge=32, maxDistance=25, genderPref=["male"]
       // We set prefs to { maxDistance: 10 }, so result merges defaults + rawPrefs
       env = {
         KV: kv as unknown as KVNamespace,
@@ -224,9 +224,9 @@ describe("Settings Handlers", () => {
 
       await settingsCommand(ctx, env);
       const callArg = (ctx.reply as any).mock.calls[0][0];
-      // Defaults: birthDate ~27 → minAge=20, maxAge=34, gender=female → ["male"]
-      expect(callArg).toContain("20");
-      expect(callArg).toContain("34");
+      // Defaults: age=25 → minAge=18, maxAge=32, gender=female → ["male"]
+      expect(callArg).toContain("18");
+      expect(callArg).toContain("32");
       expect(callArg).toContain("10 km");
       expect(callArg).toContain("Male");
     });

--- a/services/cf-bot/src/handlers/match.ts
+++ b/services/cf-bot/src/handlers/match.ts
@@ -144,7 +144,7 @@ async function ensureDefaultPreferences(
   if (Object.keys(defaults).length === 0) return;
 
   try {
-    await env.API_SERVICE.fetch(
+    const res = await env.API_SERVICE.fetch(
       new Request(`http://api/users/${userId}`, {
         method: "PUT",
         body: JSON.stringify({
@@ -153,8 +153,19 @@ async function ensureDefaultPreferences(
         headers: { "Content-Type": "application/json" },
       }),
     );
+    if (!res.ok) {
+      log.error("ensureDefaultPreferences", "API returned non-ok", {
+        userId,
+        status: res.status,
+      });
+    }
   } catch (error) {
-    console.error("Failed to set default preferences:", error);
+    log.error(
+      "ensureDefaultPreferences",
+      "Failed to set default preferences",
+      { userId },
+      error instanceof Error ? error : new Error(String(error)),
+    );
   }
 }
 

--- a/services/cf-bot/src/handlers/profile.ts
+++ b/services/cf-bot/src/handlers/profile.ts
@@ -33,9 +33,9 @@ export const profileCommand = async (
     const { user } = result;
     const lang: Language = (user.language as Language) ?? "en";
     const name = user.displayName || t("profileInterestsNotSet", lang);
-    const computedAge = user.birthDate
-      ? computeAgeFromBirthDate(user.birthDate)
-      : user.age;
+    const computedAge =
+      user.age ??
+      (user.birthDate ? computeAgeFromBirthDate(user.birthDate) : undefined);
     const ageDisplay =
       computedAge !== undefined
         ? String(computedAge)

--- a/services/cf-bot/src/handlers/settings.ts
+++ b/services/cf-bot/src/handlers/settings.ts
@@ -208,7 +208,7 @@ export const settingsCallbacks = async (
       userData = json.user;
       const bd = userData?.birthDate as string | undefined;
       const age = userData?.age as number | undefined;
-      userAge = (bd ? computeAgeFromBirthDate(bd) : age) ?? 25;
+      userAge = (age ?? (bd ? computeAgeFromBirthDate(bd) : undefined)) ?? 25;
       lang = (userData?.language as Language) ?? "en";
     }
 
@@ -285,7 +285,7 @@ export async function handleAgeRangeCallback(
       userData = (await userRes.json()) as { user?: Record<string, unknown> };
       const bd = userData.user?.birthDate as string | undefined;
       const age = userData.user?.age as number | undefined;
-      userAge = (bd ? computeAgeFromBirthDate(bd) : age) ?? 25;
+      userAge = (age ?? (bd ? computeAgeFromBirthDate(bd) : undefined)) ?? 25;
       lang = (userData.user?.language as Language) ?? "en";
     }
 

--- a/services/cf-bot/src/handlers/settings.ts
+++ b/services/cf-bot/src/handlers/settings.ts
@@ -208,7 +208,7 @@ export const settingsCallbacks = async (
       userData = json.user;
       const bd = userData?.birthDate as string | undefined;
       const age = userData?.age as number | undefined;
-      userAge = (age ?? (bd ? computeAgeFromBirthDate(bd) : undefined)) ?? 25;
+      userAge = age ?? (bd ? computeAgeFromBirthDate(bd) : undefined) ?? 25;
       lang = (userData?.language as Language) ?? "en";
     }
 
@@ -285,7 +285,7 @@ export async function handleAgeRangeCallback(
       userData = (await userRes.json()) as { user?: Record<string, unknown> };
       const bd = userData.user?.birthDate as string | undefined;
       const age = userData.user?.age as number | undefined;
-      userAge = (age ?? (bd ? computeAgeFromBirthDate(bd) : undefined)) ?? 25;
+      userAge = age ?? (bd ? computeAgeFromBirthDate(bd) : undefined) ?? 25;
       lang = (userData.user?.language as Language) ?? "en";
     }
 

--- a/services/cf-bot/src/lib/__tests__/conversations.test.ts
+++ b/services/cf-bot/src/lib/__tests__/conversations.test.ts
@@ -1000,6 +1000,22 @@ describe("handleConversationMessage", () => {
       expect(env.API_SERVICE.fetch).toHaveBeenCalledWith(
         expect.objectContaining({ method: "PUT" }),
       );
+
+      // Verify the PUT body stores city/country WITHOUT lat/lon
+      // (geocoded city-center coordinates are imprecise and should not be stored)
+      const putCall = (env.API_SERVICE.fetch as any).mock.calls.find(
+        (call: any) =>
+          call[0].method === "PUT" && String(call[0].url).includes("/users/"),
+      );
+      expect(putCall).toBeDefined();
+      const body = await putCall[0].text();
+      const parsed = JSON.parse(body);
+      expect(parsed.user.location).toMatchObject({
+        city: "Jakarta",
+        country: "Indonesia",
+      });
+      expect(parsed.user.location.latitude).toBeUndefined();
+      expect(parsed.user.location.longitude).toBeUndefined();
     } finally {
       (globalThis as any).fetch = originalFetch;
     }

--- a/services/cf-bot/src/lib/conversations.ts
+++ b/services/cf-bot/src/lib/conversations.ts
@@ -1121,7 +1121,7 @@ async function handleLocationTextConversation(
     // Geocoding failed twice — accept what user typed, store without lat/lon
     // Distance matching will skip distance filter for this user until geocoded
     const success = await updateUser(env, state.userId, {
-      location: { city, country },
+      location: { city, country, source: "geocoded" as const },
     });
     await clearConversationState(env.KV, state.userId);
     if (success) {

--- a/services/cf-bot/src/lib/conversations.ts
+++ b/services/cf-bot/src/lib/conversations.ts
@@ -654,8 +654,8 @@ export async function handleLocationMessage(
   // Reverse geocode to get city/country
   const geo = await reverseGeocodeLocation(env, latitude, longitude);
   const location = geo?.city
-    ? { latitude, longitude, city: geo.city, country: geo.country }
-    : { latitude, longitude };
+    ? { latitude, longitude, city: geo.city, country: geo.country, source: "gps" }
+    : { latitude, longitude, source: "gps" };
 
   // Only handle if we're in a location conversation or a general location share
   if (!state || state.field !== "location") {
@@ -1153,8 +1153,6 @@ async function handleLocationTextConversation(
     location: {
       city: normalizedCity,
       country: normalizedCountry,
-      latitude: lat,
-      longitude: lon,
     },
   });
   await clearConversationState(env.KV, state.userId);

--- a/services/cf-bot/src/lib/conversations.ts
+++ b/services/cf-bot/src/lib/conversations.ts
@@ -654,7 +654,13 @@ export async function handleLocationMessage(
   // Reverse geocode to get city/country
   const geo = await reverseGeocodeLocation(env, latitude, longitude);
   const location = geo?.city
-    ? { latitude, longitude, city: geo.city, country: geo.country, source: "gps" }
+    ? {
+        latitude,
+        longitude,
+        city: geo.city,
+        country: geo.country,
+        source: "gps",
+      }
     : { latitude, longitude, source: "gps" };
 
   // Only handle if we're in a location conversation or a general location share

--- a/services/cf-bot/src/lib/conversations.ts
+++ b/services/cf-bot/src/lib/conversations.ts
@@ -1152,13 +1152,12 @@ async function handleLocationTextConversation(
   const normalizedCity =
     geo.address?.city ?? geo.address?.town ?? geo.address?.village ?? city;
   const normalizedCountry = geo.address?.country ?? country;
-  const lat = parseFloat(geo.lat);
-  const lon = parseFloat(geo.lon);
 
   const success = await updateUser(env, state.userId, {
     location: {
       city: normalizedCity,
       country: normalizedCountry,
+      source: "geocoded" as const,
     },
   });
   await clearConversationState(env.KV, state.userId);

--- a/services/cf-bot/src/lib/user-utils.ts
+++ b/services/cf-bot/src/lib/user-utils.ts
@@ -1,7 +1,8 @@
 import type { MyContext } from "../types.js";
 import type { Env } from "../index.js";
 import { ApiServiceClient, ApiError } from "../services/api-client.js";
-import { createLogger } from "@meetsmatch/cf-shared";
+import { createLogger, computeDefaultPreferences } from "@meetsmatch/cf-shared";
+import type { DefaultPreferenceInput } from "@meetsmatch/cf-shared";
 
 const log = createLogger("cf-bot");
 
@@ -46,21 +47,12 @@ export function isPhoneVerified(user: UserProfile): boolean {
 export function getDefaultPreferences(
   user: Record<string, unknown>,
 ): Record<string, unknown> {
-  const age =
-    (user.age as number | undefined) ??
-    (user.birthDate
-      ? computeAgeFromBirthDate(String(user.birthDate))
-      : undefined);
-  const gender = user.gender as string | undefined;
-  if (!age || !gender) return {};
-  const minAge = Math.max(12, age - 7);
-  const maxAge = Math.min(80, age + 7);
-  const maxDistance = 25;
-  let genderPreference: string[];
-  if (gender === "male") genderPreference = ["female"];
-  else if (gender === "female") genderPreference = ["male"];
-  else genderPreference = ["male", "female", "other", "prefer_not_to_say"];
-  return { minAge, maxAge, maxDistance, genderPreference };
+  const input: DefaultPreferenceInput = {
+    age: user.age as number | undefined,
+    birthDate: user.birthDate as string | undefined,
+    gender: user.gender as string | undefined,
+  };
+  return computeDefaultPreferences(input);
 }
 
 export function getProfileCompleteness(user: UserProfile): {
@@ -104,8 +96,11 @@ export function getMissingFieldsDisplay(missing: string[]): string {
   return missing.map((f) => labels[f] || f).join(", ");
 }
 
-// --- Birthdate helpers ---
+// Re-export birthdate helpers from shared package for backwards compatibility
+export { computeAgeFromBirthDate } from "@meetsmatch/cf-shared";
 
+// parseBirthDate is kept locally because it returns an iso field not present
+// in the shared computeAgeFromBirthDate helper.
 const BIRTHDATE_REGEX = /^(0[1-9]|[12]\d|3[01])\.(0[1-9]|1[0-2])\.(\d{4})$/;
 
 export function parseBirthDate(
@@ -142,34 +137,6 @@ export function parseBirthDate(
     year,
     iso: `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`,
   };
-}
-
-export function computeAgeFromBirthDate(birthDate: string): number | undefined {
-  // Try parsing as ISO format YYYY-MM-DD first (database storage format)
-  const isoMatch = birthDate.trim().match(/^(\d{4})-(\d{2})-(\d{2})$/);
-  if (isoMatch) {
-    const year = parseInt(isoMatch[1], 10);
-    const month = parseInt(isoMatch[2], 10);
-    const day = parseInt(isoMatch[3], 10);
-    const now = new Date();
-    let age = now.getFullYear() - year;
-    const m = now.getMonth() - (month - 1);
-    if (m < 0 || (m === 0 && now.getDate() < day)) {
-      age--;
-    }
-    if (age >= 12 && age <= 80) return age;
-  }
-
-  // Fallback to DD.MM.YYYY format (user input format)
-  const parsed = parseBirthDate(birthDate);
-  if (!parsed) return undefined;
-  const now = new Date();
-  let age = now.getFullYear() - parsed.year;
-  const m = now.getMonth() - (parsed.month - 1);
-  if (m < 0 || (m === 0 && now.getDate() < parsed.day)) {
-    age--;
-  }
-  return age;
 }
 
 export function isBirthdayToday(birthDate: string | undefined): boolean {

--- a/services/cf-bot/src/lib/user-utils.ts
+++ b/services/cf-bot/src/lib/user-utils.ts
@@ -46,9 +46,11 @@ export function isPhoneVerified(user: UserProfile): boolean {
 export function getDefaultPreferences(
   user: Record<string, unknown>,
 ): Record<string, unknown> {
-  const age = user.birthDate
-    ? computeAgeFromBirthDate(String(user.birthDate))
-    : (user.age as number | undefined);
+  const age =
+    (user.age as number | undefined) ??
+    (user.birthDate
+      ? computeAgeFromBirthDate(String(user.birthDate))
+      : undefined);
   const gender = user.gender as string | undefined;
   if (!age || !gender) return {};
   const minAge = Math.max(12, age - 7);

--- a/services/cf-worker/src/jobs/__tests__/birthday.test.ts
+++ b/services/cf-worker/src/jobs/__tests__/birthday.test.ts
@@ -21,9 +21,9 @@ describe("runBirthdayJob", () => {
           const isMatchQuery = sql.includes("FROM matches m");
           const results = isMatchQuery ? matchResults : dbResults;
           return {
-            bind: vi.fn((param: string) => ({
+            bind: vi.fn((...params: unknown[]) => ({
               all: vi.fn(async () => {
-                if (param === "02-29") return { results: leapResults };
+                if (params[0] === "02-29") return { results: leapResults };
                 return { results };
               }),
               first: vi.fn(async () => ({ c: results.length })),
@@ -75,6 +75,9 @@ describe("runBirthdayJob", () => {
   });
 
   it("updates age column for birthday users", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-17T09:00:00Z"));
+
     const env = createEnv({
       dbResults: [
         { id: "user_1", first_name: "Alice", birth_date: "1990-05-17" },
@@ -86,10 +89,19 @@ describe("runBirthdayJob", () => {
     await runBirthdayJob(env);
 
     const prepareCalls = (env.DB.prepare as any).mock.calls;
-    const ageUpdateCall = prepareCalls.find((call: any[]) =>
+    const ageUpdateIdx = prepareCalls.findIndex((call: any[]) =>
       call[0].includes("UPDATE users SET age"),
     );
-    expect(ageUpdateCall).toBeDefined();
+    expect(ageUpdateIdx).toBeGreaterThanOrEqual(0);
+
+    // Verify bind params: age = 36, userId = "user_1"
+    const bindMock = (env.DB.prepare as any).mock.results[ageUpdateIdx].value
+      .bind;
+    const bindCalls = bindMock.mock.calls;
+    expect(bindCalls[0][0]).toBe(36);
+    expect(bindCalls[0][1]).toBe("user_1");
+
+    vi.useRealTimers();
   });
 
   it("handles API failure gracefully", async () => {

--- a/services/cf-worker/src/jobs/__tests__/birthday.test.ts
+++ b/services/cf-worker/src/jobs/__tests__/birthday.test.ts
@@ -69,6 +69,24 @@ describe("runBirthdayJob", () => {
     expect(calls[0][0].url).toBe("http://api/notifications");
   });
 
+  it("updates age column for birthday users", async () => {
+    const env = createEnv({
+      dbResults: [
+        { id: "user_1", first_name: "Alice", birth_date: "1990-05-17" },
+      ],
+      matchResults: [],
+      apiResponse: { ok: true },
+    });
+
+    await runBirthdayJob(env);
+
+    const prepareCalls = (env.DB.prepare as any).mock.calls;
+    const ageUpdateCall = prepareCalls.find((call: any[]) =>
+      call[0].includes("UPDATE users SET age"),
+    );
+    expect(ageUpdateCall).toBeDefined();
+  });
+
   it("handles API failure gracefully", async () => {
     const env = createEnv({
       dbResults: [

--- a/services/cf-worker/src/jobs/__tests__/birthday.test.ts
+++ b/services/cf-worker/src/jobs/__tests__/birthday.test.ts
@@ -6,11 +6,13 @@ describe("runBirthdayJob", () => {
     overrides: {
       dbResults?: Array<Record<string, unknown>>;
       matchResults?: Array<Record<string, unknown>>;
+      leapResults?: Array<Record<string, unknown>>;
       apiResponse?: { ok: boolean; status?: number; json?: unknown };
     } = {},
   ) => {
     const dbResults = overrides.dbResults ?? [];
     const matchResults = overrides.matchResults ?? [];
+    const leapResults = overrides.leapResults ?? [];
     const apiOk = overrides.apiResponse?.ok ?? true;
 
     return {
@@ -19,8 +21,11 @@ describe("runBirthdayJob", () => {
           const isMatchQuery = sql.includes("FROM matches m");
           const results = isMatchQuery ? matchResults : dbResults;
           return {
-            bind: vi.fn(() => ({
-              all: vi.fn(async () => ({ results })),
+            bind: vi.fn((param: string) => ({
+              all: vi.fn(async () => {
+                if (param === "02-29") return { results: leapResults };
+                return { results };
+              }),
               first: vi.fn(async () => ({ c: results.length })),
               run: vi.fn(async () => ({ success: true })),
             })),
@@ -136,5 +141,33 @@ describe("runBirthdayJob", () => {
     const body = JSON.parse(await new Response(req.body).text());
     const payload = JSON.parse(body.payload);
     expect(payload.message).toContain("Alice\\*Bob");
+  });
+
+  it("refreshes leap-day user ages on Feb 28 of non-leap years", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2023-02-28T09:00:00Z"));
+
+    const env = createEnv({
+      dbResults: [],
+      matchResults: [],
+      leapResults: [
+        { id: "leap_1", first_name: "Leap", birth_date: "2000-02-29" },
+      ],
+    });
+
+    await runBirthdayJob(env);
+
+    // Should query for regular birthdays, leap-day users, and age update
+    expect(env.DB.prepare).toHaveBeenCalledTimes(3);
+
+    // Should update age but NOT send notifications (no regular birthday user)
+    const runCalls = (env.DB.prepare as any).mock.calls;
+    const ageUpdateCall = runCalls.find((call: any[]) =>
+      call[0].includes("UPDATE users SET age"),
+    );
+    expect(ageUpdateCall).toBeDefined();
+    expect(env.API_SERVICE.fetch).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
   });
 });

--- a/services/cf-worker/src/jobs/birthday.ts
+++ b/services/cf-worker/src/jobs/birthday.ts
@@ -24,7 +24,8 @@ export async function runBirthdayJob(env: Env): Promise<void> {
 
     // On Feb 28 of non-leap years, also update ages for leap-day (Feb 29) births
     let leapDayUsers: Array<Record<string, unknown>> = [];
-    const isLeapYear = (y: number) => (y % 4 === 0 && y % 100 !== 0) || y % 400 === 0;
+    const isLeapYear = (y: number) =>
+      (y % 4 === 0 && y % 100 !== 0) || y % 400 === 0;
     if (month === "02" && day === "28" && !isLeapYear(now.getFullYear())) {
       const { results: leapResults } = await env.DB.prepare(
         `SELECT id, first_name, birth_date FROM users
@@ -35,7 +36,9 @@ export async function runBirthdayJob(env: Env): Promise<void> {
         .bind("02-29")
         .all();
       leapDayUsers = (leapResults ?? []) as Array<Record<string, unknown>>;
-      console.log(`[birthday] Found ${leapDayUsers.length} leap-day user(s) to refresh`);
+      console.log(
+        `[birthday] Found ${leapDayUsers.length} leap-day user(s) to refresh`,
+      );
     }
 
     const ageRefreshUsers = [...birthdayUsers, ...leapDayUsers];
@@ -59,10 +62,7 @@ export async function runBirthdayJob(env: Env): Promise<void> {
           .run();
         console.log(`[birthday] Updated age to ${age} for ${userId}`);
       } catch (error) {
-        console.error(
-          `[birthday] Failed to update age for ${userId}:`,
-          error,
-        );
+        console.error(`[birthday] Failed to update age for ${userId}:`, error);
       }
     }
 

--- a/services/cf-worker/src/jobs/birthday.ts
+++ b/services/cf-worker/src/jobs/birthday.ts
@@ -53,7 +53,16 @@ export async function runBirthdayJob(env: Env): Promise<void> {
       const today = new Date();
       let age = today.getFullYear() - birthYear;
       const m = today.getMonth() + 1 - birthMonth;
-      if (m < 0 || (m === 0 && today.getDate() < birthDay)) {
+      // For leap-day (Feb 29) births, treat Feb 28 of non-leap years as the birthday
+      const isLeapDayBirth = birthMonth === 2 && birthDay === 29;
+      const isFeb28NonLeap =
+        today.getMonth() === 1 &&
+        today.getDate() === 28 &&
+        !isLeapYear(today.getFullYear());
+      if (
+        m < 0 ||
+        (m === 0 && today.getDate() < birthDay && !(isLeapDayBirth && isFeb28NonLeap))
+      ) {
         age--;
       }
       try {

--- a/services/cf-worker/src/jobs/birthday.ts
+++ b/services/cf-worker/src/jobs/birthday.ts
@@ -22,6 +22,29 @@ export async function runBirthdayJob(env: Env): Promise<void> {
     const birthdayUsers = results ?? [];
     console.log(`[birthday] Found ${birthdayUsers.length} birthday(s) today`);
 
+    // Update age column for birthday users so cached ages stay current
+    for (const user of birthdayUsers) {
+      const birthdayUserId = String((user as Record<string, unknown>).id);
+      const birthDate = String((user as Record<string, unknown>).birth_date);
+      const birthYear = parseInt(birthDate.slice(0, 4), 10);
+      const birthMonth = parseInt(birthDate.slice(5, 7), 10);
+      const birthDay = parseInt(birthDate.slice(8, 10), 10);
+      const today = new Date();
+      let age = today.getFullYear() - birthYear;
+      const m = today.getMonth() + 1 - birthMonth;
+      if (m < 0 || (m === 0 && today.getDate() < birthDay)) {
+        age--;
+      }
+      try {
+        await env.DB.prepare("UPDATE users SET age = ? WHERE id = ?")
+          .bind(age, birthdayUserId)
+          .run();
+        console.log(`[birthday] Updated age to ${age} for ${birthdayUserId}`);
+      } catch (error) {
+        console.error(`[birthday] Failed to update age for ${birthdayUserId}:`, error);
+      }
+    }
+
     for (const user of birthdayUsers) {
       const birthdayUserId = String((user as Record<string, unknown>).id);
       const firstName = String(

--- a/services/cf-worker/src/jobs/birthday.ts
+++ b/services/cf-worker/src/jobs/birthday.ts
@@ -19,12 +19,30 @@ export async function runBirthdayJob(env: Env): Promise<void> {
       .bind(`${month}-${day}`)
       .all();
 
-    const birthdayUsers = results ?? [];
+    let birthdayUsers = results ?? [];
     console.log(`[birthday] Found ${birthdayUsers.length} birthday(s) today`);
 
-    // Update age column for birthday users so cached ages stay current
-    for (const user of birthdayUsers) {
-      const birthdayUserId = String((user as Record<string, unknown>).id);
+    // On Feb 28 of non-leap years, also update ages for leap-day (Feb 29) births
+    let leapDayUsers: Array<Record<string, unknown>> = [];
+    const isLeapYear = (y: number) => (y % 4 === 0 && y % 100 !== 0) || y % 400 === 0;
+    if (month === "02" && day === "28" && !isLeapYear(now.getFullYear())) {
+      const { results: leapResults } = await env.DB.prepare(
+        `SELECT id, first_name, birth_date FROM users
+         WHERE is_active = 1
+         AND birth_date IS NOT NULL
+         AND substr(birth_date, 6, 5) = ?`,
+      )
+        .bind("02-29")
+        .all();
+      leapDayUsers = (leapResults ?? []) as Array<Record<string, unknown>>;
+      console.log(`[birthday] Found ${leapDayUsers.length} leap-day user(s) to refresh`);
+    }
+
+    const ageRefreshUsers = [...birthdayUsers, ...leapDayUsers];
+
+    // Update age column so cached ages stay current
+    for (const user of ageRefreshUsers) {
+      const userId = String((user as Record<string, unknown>).id);
       const birthDate = String((user as Record<string, unknown>).birth_date);
       const birthYear = parseInt(birthDate.slice(0, 4), 10);
       const birthMonth = parseInt(birthDate.slice(5, 7), 10);
@@ -37,12 +55,12 @@ export async function runBirthdayJob(env: Env): Promise<void> {
       }
       try {
         await env.DB.prepare("UPDATE users SET age = ? WHERE id = ?")
-          .bind(age, birthdayUserId)
+          .bind(age, userId)
           .run();
-        console.log(`[birthday] Updated age to ${age} for ${birthdayUserId}`);
+        console.log(`[birthday] Updated age to ${age} for ${userId}`);
       } catch (error) {
         console.error(
-          `[birthday] Failed to update age for ${birthdayUserId}:`,
+          `[birthday] Failed to update age for ${userId}:`,
           error,
         );
       }

--- a/services/cf-worker/src/jobs/birthday.ts
+++ b/services/cf-worker/src/jobs/birthday.ts
@@ -41,7 +41,10 @@ export async function runBirthdayJob(env: Env): Promise<void> {
           .run();
         console.log(`[birthday] Updated age to ${age} for ${birthdayUserId}`);
       } catch (error) {
-        console.error(`[birthday] Failed to update age for ${birthdayUserId}:`, error);
+        console.error(
+          `[birthday] Failed to update age for ${birthdayUserId}:`,
+          error,
+        );
       }
     }
 

--- a/services/cf-worker/src/jobs/birthday.ts
+++ b/services/cf-worker/src/jobs/birthday.ts
@@ -61,7 +61,9 @@ export async function runBirthdayJob(env: Env): Promise<void> {
         !isLeapYear(today.getFullYear());
       if (
         m < 0 ||
-        (m === 0 && today.getDate() < birthDay && !(isLeapDayBirth && isFeb28NonLeap))
+        (m === 0 &&
+          today.getDate() < birthDay &&
+          !(isLeapDayBirth && isFeb28NonLeap))
       ) {
         age--;
       }

--- a/services/cf-worker/src/jobs/birthday.ts
+++ b/services/cf-worker/src/jobs/birthday.ts
@@ -1,4 +1,5 @@
 import type { Env } from "../index.js";
+import { computeAgeFromBirthDate } from "@meetsmatch/cf-shared";
 
 export async function runBirthdayJob(env: Env): Promise<void> {
   console.log("[birthday] Starting birthday notification job");
@@ -47,26 +48,22 @@ export async function runBirthdayJob(env: Env): Promise<void> {
     for (const user of ageRefreshUsers) {
       const userId = String((user as Record<string, unknown>).id);
       const birthDate = String((user as Record<string, unknown>).birth_date);
-      const birthYear = parseInt(birthDate.slice(0, 4), 10);
+      let age = computeAgeFromBirthDate(birthDate);
+      if (age == null) continue;
+
+      // For leap-day (Feb 29) births, treat Feb 28 of non-leap years as the birthday
       const birthMonth = parseInt(birthDate.slice(5, 7), 10);
       const birthDay = parseInt(birthDate.slice(8, 10), 10);
       const today = new Date();
-      let age = today.getFullYear() - birthYear;
-      const m = today.getMonth() + 1 - birthMonth;
-      // For leap-day (Feb 29) births, treat Feb 28 of non-leap years as the birthday
       const isLeapDayBirth = birthMonth === 2 && birthDay === 29;
       const isFeb28NonLeap =
         today.getMonth() === 1 &&
         today.getDate() === 28 &&
         !isLeapYear(today.getFullYear());
-      if (
-        m < 0 ||
-        (m === 0 &&
-          today.getDate() < birthDay &&
-          !(isLeapDayBirth && isFeb28NonLeap))
-      ) {
-        age--;
+      if (isLeapDayBirth && isFeb28NonLeap) {
+        age++;
       }
+
       try {
         await env.DB.prepare("UPDATE users SET age = ? WHERE id = ?")
           .bind(age, userId)


### PR DESCRIPTION
## Bug Fixes

### 1. Age not updating when manually changed in DB
**Root cause:** The bot always recomputed age from `birthDate` whenever it existed, completely ignoring the `age` column. If an admin manually updated `age` but left `birthDate` unchanged, the UI still showed the old age.

**Fix:** Changed age resolution logic in `profile.ts` and `settings.ts` to trust the `age` column first, and only fall back to computing from `birthDate` when `age` is missing.

### 2. New male users see male matches
**Root cause:** Two issues combined:
- Bot side: `ensureDefaultPreferences` fired a PUT request but never checked `response.ok`. A 404/500 response resolved the promise, so the failure was silently ignored.
- API side: When a user's `preferences` was `{}` (empty object), the SQL query simply skipped the gender filter entirely because `prefs?.genderPreference` was `undefined`.

**Fix:**
- Bot side: Verify the PUT response status and log an error when non-ok.
- API side: In `getPotentialMatches`, compute default preferences inline if the user has no `genderPreference` set. This makes the API self-healing regardless of bot-side failures.

### Tests Added
- `profile.test.ts`: verifies `age` column is trusted over `birthDate`
- `match.test.ts` (bot): verifies match discovery still proceeds when default-preference PUT fails
- `match.test.ts` (API): verifies default gender/age filtering for male, female, and `other` genders with empty preferences

---
Closes potential bug reports around age display and default gender preferences.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Smarter default matching when preferences are empty; sensible gender/age/distance defaults applied.
  * Birthday job refreshes ages (including leap-day handling) before notifications.
  * Location records include a source tag; manual locations save city/country without GPS coords.

* **Bug Fixes**
  * Distance filtering and scoring skip for geocoded locations to avoid excluding matches.
  * Age display/selection now prefer an explicitly set age over computing from birthdate.
  * Bot logs failures when saving defaults but continues to respond gracefully.

* **Tests**
  * Expanded coverage for preference defaults, age parsing, location handling, scoring, and matching.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/irfndi/meets-match/pull/142?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->