### PR TITLE
fix: reorder match card before promotional prompts and notification banners

### DIFF
--- a/services/cf-bot/src/index.ts
+++ b/services/cf-bot/src/index.ts
@@ -148,6 +148,9 @@ function createBot(env: Env): Bot<MyContext> {
 
     await next();
 
+    const stateAfter = await getConversationState(env.KV, userId);
+    if (stateAfter) return;
+
     const notifications = await getNotifications(env, userId);
     const hasLikes = notifications.some((n) => n.type === "like");
     const hasMutual = notifications.some((n) => n.type === "mutual_match");


### PR DESCRIPTION
## Summary

Fixes UX ordering issues where promotional prompts and notification banners were shown before the primary content users requested.

## Changes

- `showNextMatch`: send match card before premium ad, referral prompt, and relaxed-search notice
- `matchCommand`: send first match before relaxed-search inline keyboard notice
- `index.ts`: move notification check middleware to run after handlers complete

## Bug Report Evidence

User reported: when tapping 👎 (dislike) on a match, they see "👑 Unlock Premium Features" banner, then the next match card appears *below* the banner. The user expected to see the next match card immediately after their action.

## Files Changed

- `services/cf-bot/src/handlers/match.ts`
- `services/cf-bot/src/index.ts`
- `services/cf-bot/src/handlers/__tests__/match.test.ts` (4 new tests),

## Summary by Sourcery

Reorder match flow responses so that the next match card is delivered before promotional prompts and notification banners, and ensure notification checks run after primary handlers complete.

Bug Fixes:
- Ensure the next match card is sent before premium ads and referral prompts in the match queue flow.
- Ensure relaxed-search notices are shown after the first match card instead of before it.
- Ensure user notification banners (likes/mutual matches) are processed after handling the current user interaction.

Enhancements:
- Expose showNextMatch for reuse and strengthen match flow behavior with additional ordering tests.

Tests:
- Add tests verifying the relative ordering of match cards, premium ads, and referral prompts, and that ads are suppressed for premium users or at the first match.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Match cards now appear before promotional content for free-tier users, with premium ads properly hidden from premium subscribers.
  * Corrected timing of search-related notifications in the message queue.

* **Tests**
  * Expanded test coverage to verify correct ordering of match cards and ads based on user tier.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/irfndi/meets-match/pull/144?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->