### PR TITLE
⚡ Bolt: [performance improvement] Precompute distance and Set in match scoring loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,4 +17,4 @@
 
 1. Precompute `currentUserInterestsSet` outside the loop and pass it in as an option to `calculateMatchScore`.
 2. Precompute the `haversine` distance for the candidate once, avoiding duplicate calculations.
-3. Replace dynamic calculation of `Math.PI / 180.0` with a pre-computed `TO_RAD` constant outside `haversine`.
+3. Replace dynamic calculation of `Math.PI / 180.0` with a precomputed `TO_RAD` constant outside `haversine`.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,12 @@
 
 **Learning:** When calculating time differences for multiple items inside a hot loop (like checking candidate timestamps in match scoring), using `new Date(dateString).getTime()` causes significant unnecessary memory allocation and garbage collection for full Date objects.
 **Action:** Use the much faster `Date.parse(dateString)` instead of `new Date(dateString).getTime()`. Also, hoist constant time evaluations like `new Date().getTime()` to a `nowTime` variable outside the loop to avoid redundant calls.
+
+## 2026-05-30 - Haversine Distance and Set Allocation Optimization in Hot Loop
+
+**Learning:** Within the hot loop `getPotentialMatches` scoring logic, `haversine` distance was calculated multiple times (up to 3 times per candidate) due to duplicate coordinate checks across strict and soft constraint filtering, as well as final scoring. Furthermore, a new `Set` was being instantiated inside `calculateMatchScore` for the current user's interests during _every_ candidate evaluation. Additionally, `Math.PI / 180.0` was calculated dynamically in `haversine`.
+**Action:**
+
+1. Precompute `currentUserInterestsSet` outside the loop and pass it in as an option to `calculateMatchScore`.
+2. Precompute the `haversine` distance for the candidate once, avoiding duplicate calculations.
+3. Replace dynamic calculation of `Math.PI / 180.0` with a pre-computed `TO_RAD` constant outside `haversine`.

--- a/services/cf-api/src/models/match.ts
+++ b/services/cf-api/src/models/match.ts
@@ -544,19 +544,23 @@ export class MatchRepository {
 
             // --- Precompute Distance ---
             let precomputedDistance: number | undefined;
+            const loc1 = currentUser.location;
+            const loc2 = candidate.location;
             if (
-              currentUser.location?.latitude != null &&
-              currentUser.location?.longitude != null &&
-              candidate.location?.latitude != null &&
-              candidate.location?.longitude != null &&
-              currentUser.location.source !== "geocoded" &&
-              candidate.location.source !== "geocoded"
+              loc1 &&
+              loc2 &&
+              loc1.latitude != null &&
+              loc1.longitude != null &&
+              loc2.latitude != null &&
+              loc2.longitude != null &&
+              loc1.source !== "geocoded" &&
+              loc2.source !== "geocoded"
             ) {
               precomputedDistance = haversine(
-                currentUser.location.latitude,
-                currentUser.location.longitude,
-                candidate.location.latitude,
-                candidate.location.longitude,
+                loc1.latitude,
+                loc1.longitude,
+                loc2.latitude,
+                loc2.longitude,
               );
             }
 

--- a/services/cf-api/src/models/match.ts
+++ b/services/cf-api/src/models/match.ts
@@ -503,6 +503,12 @@ export class MatchRepository {
 
         // 3. Filter and score candidates
         const nowTime = Date.now();
+
+        const currentUserInterestsSet =
+          currentUser.interests && currentUser.interests.length > 0
+            ? new Set(currentUser.interests)
+            : undefined;
+
         const scored = rows
           .map((row) => {
             const candidate = this.rowToUser(row);
@@ -536,6 +542,24 @@ export class MatchRepository {
             const myAction = isUser1InMatch ? user1Action : user2Action;
             const otherAction = isUser1InMatch ? user2Action : user1Action;
 
+            // --- Precompute Distance ---
+            let precomputedDistance: number | undefined;
+            if (
+              currentUser.location?.latitude != null &&
+              currentUser.location?.longitude != null &&
+              candidate.location?.latitude != null &&
+              candidate.location?.longitude != null &&
+              currentUser.location.source !== "geocoded" &&
+              candidate.location.source !== "geocoded"
+            ) {
+              precomputedDistance = haversine(
+                currentUser.location.latitude,
+                currentUser.location.longitude,
+                candidate.location.latitude,
+                candidate.location.longitude,
+              );
+            }
+
             // --- Bidirectional preference check ---
             // In strict mode: hard-filter candidates whose preferences don't
             // include the current user. In relaxed mode: skip these checks so
@@ -568,45 +592,21 @@ export class MatchRepository {
               // Distance from candidate's perspective
               // Skip when either user has geocoded (imprecise) coordinates.
               if (
-                candidate.location?.latitude != null &&
-                candidate.location?.longitude != null &&
-                currentUser.location?.latitude != null &&
-                currentUser.location?.longitude != null &&
-                candidate.location.source !== "geocoded" &&
-                currentUser.location.source !== "geocoded" &&
+                precomputedDistance !== undefined &&
                 candidatePrefs?.maxDistance
               ) {
-                const dist = haversine(
-                  candidate.location.latitude,
-                  candidate.location.longitude,
-                  currentUser.location.latitude,
-                  currentUser.location.longitude,
-                );
-                if (dist > candidatePrefs.maxDistance) return null;
+                if (precomputedDistance > candidatePrefs.maxDistance)
+                  return null;
               }
             }
 
             // --- Current user's distance hard constraint ---
             // Skip when either user has geocoded (imprecise) coordinates.
-            if (
-              currentUser.location?.latitude != null &&
-              currentUser.location?.longitude != null &&
-              candidate.location?.latitude != null &&
-              candidate.location?.longitude != null &&
-              currentUser.location.source !== "geocoded" &&
-              candidate.location.source !== "geocoded" &&
-              prefs?.maxDistance
-            ) {
-              const dist = haversine(
-                currentUser.location.latitude,
-                currentUser.location.longitude,
-                candidate.location.latitude,
-                candidate.location.longitude,
-              );
+            if (precomputedDistance !== undefined && prefs?.maxDistance) {
               const effectiveMaxDist = relaxFilters
                 ? Math.min(500, prefs.maxDistance * 2)
                 : prefs.maxDistance;
-              if (dist > effectiveMaxDist) return null;
+              if (precomputedDistance > effectiveMaxDist) return null;
             }
 
             // --- Cooldown filtering ---
@@ -657,7 +657,10 @@ export class MatchRepository {
             }
 
             // --- Calculate base score ---
-            let baseScore = calculateMatchScore(currentUser, candidate).total;
+            let baseScore = calculateMatchScore(currentUser, candidate, {
+              precomputedDistance,
+              user1InterestsSet: currentUserInterestsSet,
+            }).total;
 
             // Variety: penalize recently shown profiles
             if (viewedTime !== null) {
@@ -842,6 +845,8 @@ export class MatchRepository {
   }
 }
 
+const TO_RAD = Math.PI / 180.0;
+
 export function haversine(
   lat1: number,
   lon1: number,
@@ -849,10 +854,10 @@ export function haversine(
   lon2: number,
 ): number {
   const R = 6371; // Earth radius in km
-  const dLat = (lat2 - lat1) * (Math.PI / 180.0);
-  const dLon = (lon2 - lon1) * (Math.PI / 180.0);
-  const lat1Rad = lat1 * (Math.PI / 180.0);
-  const lat2Rad = lat2 * (Math.PI / 180.0);
+  const dLat = (lat2 - lat1) * TO_RAD;
+  const dLon = (lon2 - lon1) * TO_RAD;
+  const lat1Rad = lat1 * TO_RAD;
+  const lat2Rad = lat2 * TO_RAD;
   const a =
     Math.sin(dLat / 2) * Math.sin(dLat / 2) +
     Math.sin(dLon / 2) *
@@ -873,6 +878,10 @@ interface MatchScore {
 export function calculateMatchScore(
   user1: typeof User.Type,
   user2: typeof User.Type,
+  options?: {
+    precomputedDistance?: number;
+    user1InterestsSet?: Set<string>;
+  },
 ): MatchScore {
   const score: MatchScore = {
     location: 0,
@@ -886,7 +895,12 @@ export function calculateMatchScore(
   // which are imprecise and would give misleading scores.
   // Old data without a source field is treated as potentially GPS for
   // backward compatibility.
-  if (
+  if (options?.precomputedDistance !== undefined) {
+    const maxDist = user1.preferences?.maxDistance ?? 20.0;
+    if (options.precomputedDistance <= maxDist) {
+      score.location = 1.0 - options.precomputedDistance / maxDist;
+    }
+  } else if (
     user1.location?.latitude != null &&
     user1.location?.longitude != null &&
     user2.location?.latitude != null &&
@@ -916,7 +930,7 @@ export function calculateMatchScore(
     let intersectionSize = 0;
     let unionSize = 0;
 
-    const set1 = new Set(user1.interests);
+    const set1 = options?.user1InterestsSet ?? new Set(user1.interests);
     const set2 = new Set(user2.interests);
 
     const [smaller, larger] =


### PR DESCRIPTION
💡 What: Precomputes the `haversine` distance and the `currentUserInterestsSet` outside the hot evaluation loop in `getPotentialMatches`, passing them into `calculateMatchScore`. Additionally pre-calculates the `Math.PI / 180.0` constant in the `haversine` function.
🎯 Why: In the `getPotentialMatches` scoring loop, the `haversine` distance was being recalculated up to 3 times per candidate (strict filter, soft filter, and scoring). Furthermore, a new `Set` was being created for the current user's interests during *every* candidate evaluation within `calculateMatchScore`.
📊 Impact: Significantly reduces CPU overhead per candidate in the hot `getPotentialMatches` loop by eliminating redundant object allocations (`Set`) and expensive duplicate math operations, allowing the database query to process matches much faster.
🔬 Measurement: Verify by running `bun run test` in `services/cf-api` to ensure `calculateMatchScore` property-based tests and `match.test.ts` still pass. Check `.jules/bolt.md` for journal documentation.

---
*PR created automatically by Jules for task [4879364343472505241](https://jules.google.com/task/4879364343472505241) started by @irfndi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized candidate matching and filtering calculations to improve response times when browsing potential matches.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/irfndi/meets-match/pull/152?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->