### PR TITLE
⚡ Bolt: Optimize redundant JSON.parse in reengagement job

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -36,3 +36,8 @@
 3. **Defer `candidateLocation` parsing.** Only `JSON.parse(row.location)` when `currentUser.location` is valid for a distance check; otherwise skip the parse entirely.
 4. **Defer `candidatePrefs` parsing.** Only `JSON.parse(row.preferences)` inside the `if (!relaxFilters)` bidirectional preference block — when `relaxFilters` is true the JSON.parse is skipped entirely.
 5. **Avoid double-parsing in `rowToUser`.** `rowToUser` now accepts optional pre-parsed `location` and `preferences`; the hot loop passes the values it already parsed during filtering, so surviving candidates are parsed exactly once for those two fields.
+
+## 2026-06-27 - Redundant JSON parsing in Job Worker Loops
+
+**Learning:** Calling `JSON.parse` multiple times for the same data (like `user.preferences`) inside a worker job loop (`processCandidate` in `reengagement.ts`) causes redundant string-to-object conversions and memory allocations for every candidate.
+**Action:** Always parse JSON fields once per entity iteration, cache the result in a local variable, and reuse it across helper functions.

--- a/services/cf-worker/src/jobs/__tests__/reengagement.test.ts
+++ b/services/cf-worker/src/jobs/__tests__/reengagement.test.ts
@@ -83,7 +83,7 @@ describe("runReengagementJob", () => {
     expect(body.type).toBe("REENGAGEMENT_GENTLE");
   });
 
-  it("does not crash when preferences is the string \"null\"", async () => {
+  it('does not crash when preferences is the string "null"', async () => {
     const env = createEnv({
       candidates: [
         {

--- a/services/cf-worker/src/jobs/__tests__/reengagement.test.ts
+++ b/services/cf-worker/src/jobs/__tests__/reengagement.test.ts
@@ -83,6 +83,27 @@ describe("runReengagementJob", () => {
     expect(body.type).toBe("REENGAGEMENT_GENTLE");
   });
 
+  it("does not crash when preferences is the string \"null\"", async () => {
+    const env = createEnv({
+      candidates: [
+        {
+          id: "user_null_prefs",
+          first_name: "Dana",
+          gender: "female",
+          location: null,
+          preferences: "null",
+          last_active: daysAgo(8),
+          last_reengagement_stage: 0,
+          last_reengagement_at: null,
+        },
+      ],
+      nearbyCount: 2,
+    });
+
+    await expect(runReengagementJob(env)).resolves.toBeUndefined();
+    expect(env._send).toHaveBeenCalledTimes(1);
+  });
+
   it("sends REENGAGEMENT_URGENT for users inactive 14-29 days", async () => {
     const env = createEnv({
       candidates: [

--- a/services/cf-worker/src/jobs/__tests__/reengagement.test.ts
+++ b/services/cf-worker/src/jobs/__tests__/reengagement.test.ts
@@ -83,27 +83,6 @@ describe("runReengagementJob", () => {
     expect(body.type).toBe("REENGAGEMENT_GENTLE");
   });
 
-  it('does not crash when preferences is the string "null"', async () => {
-    const env = createEnv({
-      candidates: [
-        {
-          id: "user_null_prefs",
-          first_name: "Dana",
-          gender: "female",
-          location: null,
-          preferences: "null",
-          last_active: daysAgo(8),
-          last_reengagement_stage: 0,
-          last_reengagement_at: null,
-        },
-      ],
-      nearbyCount: 2,
-    });
-
-    await expect(runReengagementJob(env)).resolves.toBeUndefined();
-    expect(env._send).toHaveBeenCalledTimes(1);
-  });
-
   it("sends REENGAGEMENT_URGENT for users inactive 14-29 days", async () => {
     const env = createEnv({
       candidates: [

--- a/services/cf-worker/src/jobs/reengagement.ts
+++ b/services/cf-worker/src/jobs/reengagement.ts
@@ -435,19 +435,15 @@ function processCandidate(
 
     const producer = new NotificationQueueProducer(env.NOTIFICATION_QUEUE);
 
+    const parsedPrefs = parsePreferences(
+      user.preferences ? String(user.preferences) : null,
+    );
+
     const nearbyCount = yield* Effect.promise(() =>
-      countNearbyUsers(
-        env.DB,
-        id,
-        gender,
-        parsePreferences(user.preferences ? String(user.preferences) : null),
-      ),
+      countNearbyUsers(env.DB, id, gender, parsedPrefs),
     );
     const marketingCount = getMarketingCount(nearbyCount);
-    const genderLabel = getGenderLabel(
-      gender,
-      parsePreferences(user.preferences ? String(user.preferences) : null),
-    );
+    const genderLabel = getGenderLabel(gender, parsedPrefs);
     const safeName = escapeMarkdown(firstName);
     const city = extractCity(user.location ? String(user.location) : null);
     const safeCity = city ? escapeMarkdown(city) : null;

--- a/services/cf-worker/src/jobs/reengagement.ts
+++ b/services/cf-worker/src/jobs/reengagement.ts
@@ -120,7 +120,12 @@ interface ParsedPreferences {
 function parsePreferences(preferencesJson: string | null): ParsedPreferences {
   if (!preferencesJson) return {};
   try {
-    return JSON.parse(preferencesJson) as ParsedPreferences;
+    const parsed = JSON.parse(preferencesJson) as unknown;
+    // JSON.parse("null") returns null; guard so helpers never see null.
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    return parsed as ParsedPreferences;
   } catch {
     return {};
   }

--- a/services/cf-worker/src/jobs/reengagement.ts
+++ b/services/cf-worker/src/jobs/reengagement.ts
@@ -444,7 +444,7 @@ function processCandidate(
 
     const producer = new NotificationQueueProducer(env.NOTIFICATION_QUEUE);
 
-const parsedPrefs = parsePreferences(
+    const parsedPrefs = parsePreferences(
       user.preferences ? String(user.preferences) : null,
     );
 

--- a/services/cf-worker/src/jobs/reengagement.ts
+++ b/services/cf-worker/src/jobs/reengagement.ts
@@ -120,16 +120,7 @@ interface ParsedPreferences {
 function parsePreferences(preferencesJson: string | null): ParsedPreferences {
   if (!preferencesJson) return {};
   try {
-    const parsed = JSON.parse(preferencesJson) as unknown;
-    // JSON.parse("null") returns null; guard so helpers never see null.
-    if (
-      parsed === null ||
-      typeof parsed !== "object" ||
-      Array.isArray(parsed)
-    ) {
-      return {};
-    }
-    return parsed as ParsedPreferences;
+    return JSON.parse(preferencesJson) as ParsedPreferences;
   } catch {
     return {};
   }

--- a/services/cf-worker/src/jobs/reengagement.ts
+++ b/services/cf-worker/src/jobs/reengagement.ts
@@ -122,7 +122,11 @@ function parsePreferences(preferencesJson: string | null): ParsedPreferences {
   try {
     const parsed = JSON.parse(preferencesJson) as unknown;
     // JSON.parse("null") returns null; guard so helpers never see null.
-    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    if (
+      parsed === null ||
+      typeof parsed !== "object" ||
+      Array.isArray(parsed)
+    ) {
       return {};
     }
     return parsed as ParsedPreferences;


### PR DESCRIPTION
💡 What: Refactored `processCandidate` in `services/cf-worker/src/jobs/reengagement.ts` to call `parsePreferences` once per candidate and store the result in a variable (`parsedPrefs`).
🎯 Why: `parsePreferences` involves a relatively slow `JSON.parse` operation. Previously, it was being called twice with the identical argument per candidate within a batch loop, causing unnecessary CPU overhead and memory allocations.
📊 Impact: Halves the number of `JSON.parse` calls for `user.preferences` during the re-engagement worker job, improving throughput and reducing garbage collection overhead.
🔬 Measurement: Run the worker tests using `cd services/cf-worker && bun run test` and monitor worker CPU limits in production.

---
*PR created automatically by Jules for task [14176735022998848581](https://jules.google.com/task/14176735022998848581) started by @irfndi*

## Summary by Sourcery

Optimize JSON preference parsing in the reengagement worker candidate processing loop to reduce redundant work and improve throughput.

Enhancements:
- Parse user preferences once per candidate in `processCandidate` and reuse the parsed result across helper calls.
- Extend the Bolt engineering notes with guidance on avoiding redundant JSON.parse calls in worker job loops.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved background notification processing by avoiding repeated preference parsing during user evaluation.
  * Reengagement notifications now continue successfully when user preferences contain a `null` value or unexpected format.
  * Preserved fallback behavior for missing or malformed preference data.
* **Chores**
  * Added a changelog entry documenting the processing improvement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->