### PR TITLE
⚡ Bolt: [performance improvement] Cache parsed preferences in reengagement loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -36,3 +36,8 @@
 3. **Defer `candidateLocation` parsing.** Only `JSON.parse(row.location)` when `currentUser.location` is valid for a distance check; otherwise skip the parse entirely.
 4. **Defer `candidatePrefs` parsing.** Only `JSON.parse(row.preferences)` inside the `if (!relaxFilters)` bidirectional preference block — when `relaxFilters` is true the JSON.parse is skipped entirely.
 5. **Avoid double-parsing in `rowToUser`.** `rowToUser` now accepts optional pre-parsed `location` and `preferences`; the hot loop passes the values it already parsed during filtering, so surviving candidates are parsed exactly once for those two fields.
+
+## 2026-06-20 - Redundant JSON Parsing in Worker Loops
+
+**Learning:** Within background worker jobs (e.g., re-engagement emails processing candidate loops), entity fields like user preferences are sometimes repeatedly parsed from JSON for different helper functions (e.g., `countNearbyUsers` and `getGenderLabel` sequentially). This causes unnecessary object allocation and parsing overhead that scales linearly with loop iterations.
+**Action:** Always parse JSON fields once per iteration, cache the result locally (`const parsedPrefs = parsePreferences(...)`), and pass the typed object explicitly to downstream helpers to prevent redundant `JSON.parse` executions.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -39,5 +39,5 @@
 
 ## 2026-06-20 - Redundant JSON Parsing in Worker Loops
 
-**Learning:** Within background worker jobs (e.g., re-engagement emails processing candidate loops), entity fields like user preferences are sometimes repeatedly parsed from JSON for different helper functions (e.g., `countNearbyUsers` and `getGenderLabel` sequentially). This causes unnecessary object allocation and parsing overhead that scales linearly with loop iterations.
+**Learning:** Within background worker jobs (e.g., re-engagement email jobs that process candidate loops), entity fields like user preferences are sometimes repeatedly parsed from JSON for different helper functions (e.g., `countNearbyUsers` and `getGenderLabel` sequentially). This causes unnecessary object allocation and parsing overhead that scales linearly with loop iterations.
 **Action:** Always parse JSON fields once per iteration, cache the result locally (`const parsedPrefs = parsePreferences(...)`), and pass the typed object explicitly to downstream helpers to prevent redundant `JSON.parse` executions.

--- a/services/cf-worker/src/jobs/reengagement.ts
+++ b/services/cf-worker/src/jobs/reengagement.ts
@@ -444,7 +444,7 @@ function processCandidate(
 
     const producer = new NotificationQueueProducer(env.NOTIFICATION_QUEUE);
 
-const parsedPrefs = parsePreferences(
+    const parsedPrefs = parsePreferences(
       user.preferences ? String(user.preferences) : null,
     );
 

--- a/services/cf-worker/src/jobs/reengagement.ts
+++ b/services/cf-worker/src/jobs/reengagement.ts
@@ -435,18 +435,24 @@ function processCandidate(
 
     const producer = new NotificationQueueProducer(env.NOTIFICATION_QUEUE);
 
+    // ⚡ Bolt Optimization: Parse preferences once and cache locally
+    // to prevent redundant JSON.parse operations in both countNearbyUsers and getGenderLabel.
+    const parsedPrefs = parsePreferences(
+      user.preferences ? String(user.preferences) : null,
+    );
+
     const nearbyCount = yield* Effect.promise(() =>
       countNearbyUsers(
         env.DB,
         id,
         gender,
-        parsePreferences(user.preferences ? String(user.preferences) : null),
+        parsedPrefs,
       ),
     );
     const marketingCount = getMarketingCount(nearbyCount);
     const genderLabel = getGenderLabel(
       gender,
-      parsePreferences(user.preferences ? String(user.preferences) : null),
+      parsedPrefs,
     );
     const safeName = escapeMarkdown(firstName);
     const city = extractCity(user.location ? String(user.location) : null);

--- a/services/cf-worker/src/jobs/reengagement.ts
+++ b/services/cf-worker/src/jobs/reengagement.ts
@@ -442,18 +442,10 @@ function processCandidate(
     );
 
     const nearbyCount = yield* Effect.promise(() =>
-      countNearbyUsers(
-        env.DB,
-        id,
-        gender,
-        parsedPrefs,
-      ),
+      countNearbyUsers(env.DB, id, gender, parsedPrefs),
     );
     const marketingCount = getMarketingCount(nearbyCount);
-    const genderLabel = getGenderLabel(
-      gender,
-      parsedPrefs,
-    );
+    const genderLabel = getGenderLabel(gender, parsedPrefs);
     const safeName = escapeMarkdown(firstName);
     const city = extractCity(user.location ? String(user.location) : null);
     const safeCity = city ? escapeMarkdown(city) : null;


### PR DESCRIPTION
💡 **What**: Extracted the result of `parsePreferences` into a local variable (`parsedPrefs`) inside the `processCandidate` loop in `services/cf-worker/src/jobs/reengagement.ts`.
🎯 **Why**: Previously, `user.preferences` was passed through `parsePreferences` twice per user iteration, resulting in duplicate and unnecessary `JSON.parse` operations. This redundant parsing caused unnecessary object allocation and garbage collection overhead in the worker job.
📊 **Impact**: Reduces `JSON.parse` execution for the preferences field by 50% for each processed candidate, resulting in faster iteration and lower memory consumption during re-engagement batch processing.
🔬 **Measurement**: Verified by running the worker's unit test suite. Execution time for large batches in production will show reduced CPU time spent in parsing.

---
*PR created automatically by Jules for task [1517415420236367233](https://jules.google.com/task/1517415420236367233) started by @irfndi*

## Summary by Sourcery

Optimize re-engagement worker candidate processing by caching parsed user preferences for reuse across helper calls.

Enhancements:
- Cache parsed user preferences once per candidate in the re-engagement worker loop and reuse them across nearby user counting and gender label computation.

Documentation:
- Document the performance guideline to parse JSON fields once per worker iteration and pass cached results to downstream helpers in the Bolt playbook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced redundant preference data processing during background re-engagement tasks.
  * Improved efficiency when evaluating candidate users without changing visible behavior.

* **Documentation**
  * Added guidance on avoiding repeated JSON parsing in worker loops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->