### PR TITLE
⚡ Bolt: [performance improvement] Avoid redundant JSON parsing of preferences

### DIFF
--- a/services/cf-worker/src/jobs/reengagement.ts
+++ b/services/cf-worker/src/jobs/reengagement.ts
@@ -435,19 +435,16 @@ function processCandidate(
 
     const producer = new NotificationQueueProducer(env.NOTIFICATION_QUEUE);
 
+    // ⚡ Bolt Optimization: Parse preferences once per candidate to avoid duplicate JSON.parse overhead
+    const parsedPreferences = parsePreferences(
+      user.preferences ? String(user.preferences) : null,
+    );
+
     const nearbyCount = yield* Effect.promise(() =>
-      countNearbyUsers(
-        env.DB,
-        id,
-        gender,
-        parsePreferences(user.preferences ? String(user.preferences) : null),
-      ),
+      countNearbyUsers(env.DB, id, gender, parsedPreferences),
     );
     const marketingCount = getMarketingCount(nearbyCount);
-    const genderLabel = getGenderLabel(
-      gender,
-      parsePreferences(user.preferences ? String(user.preferences) : null),
-    );
+    const genderLabel = getGenderLabel(gender, parsedPreferences);
     const safeName = escapeMarkdown(firstName);
     const city = extractCity(user.location ? String(user.location) : null);
     const safeCity = city ? escapeMarkdown(city) : null;


### PR DESCRIPTION
💡 What: Lift the parsing of `user.preferences` into a `parsedPreferences` variable at the start of `processCandidate` in the `reengagement.ts` worker, so it can be passed to both `countNearbyUsers` and `getGenderLabel` rather than being evaluated twice via `parsePreferences(user.preferences ? String(user.preferences) : null)`.

🎯 Why: To avoid redundant execution of `JSON.parse` and multiple memory allocations on every pass of the `processCandidate` loop, reducing CPU and GC pressure during the execution of the batch reengagement worker.

📊 Impact: Reduces `JSON.parse` calls for `user.preferences` by exactly 50% during candidate processing, leading to marginally lower per-candidate execution times and smoother garbage collection.

🔬 Measurement: Observe memory footprint and CPU time when batching `processCandidate` runs across thousands of users in cloud environments. No regressions were introduced during local execution of `bun run test` in `services/cf-worker`.

---
*PR created automatically by Jules for task [17585952229740975509](https://jules.google.com/task/17585952229740975509) started by @irfndi*

## Summary by Sourcery

Enhancements:
- Parse user preferences once per candidate in the reengagement worker and reuse the result across downstream computations to reduce JSON parsing overhead.